### PR TITLE
feat: allow to configure TLS settings in leaf connections

### DIFF
--- a/deploy/nats-event-bus/Chart.yaml
+++ b/deploy/nats-event-bus/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: nats-event-bus
 description: NATS Event Bus with mTLS support
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"
 
 dependencies:
   - name: nats

--- a/deploy/nats-event-bus/templates/_helpers.tpl
+++ b/deploy/nats-event-bus/templates/_helpers.tpl
@@ -13,3 +13,34 @@ CSC
 CPC
 {{- end -}}
 {{- end -}}
+
+{{/*
+natsConfFields: Renders a NATS configuration block body from a flat map.
+Strings are quoted; booleans and numbers are unquoted.
+*/}}
+{{- define "nats-event-bus.natsConfFields" }}
+{{- range $key, $value := . }}
+{{- if kindIs "map" $value }}
+{{ $key }}: {
+{{ include "nats-event-bus.natsConfFields" $value | indent 2 }}
+}
+{{- else if or (kindIs "bool" $value) (kindIs "int" $value) (kindIs "float64" $value) }}
+{{ $key }}: {{ $value }}
+{{- else }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+natsConfBlock: Renders a named NATS configuration block (e.g. tls: { ... }).
+*/}}
+{{- define "nats-event-bus.natsConfBlock" -}}
+{{- $name := .name -}}
+{{- $fields := .fields -}}
+{{- if and $name $fields (not (empty $fields)) -}}
+{{ $name }}: {
+{{ include "nats-event-bus.natsConfFields" $fields | indent 2 }}
+}
+{{- end -}}
+{{- end -}}

--- a/deploy/nats-event-bus/templates/nats-leafnodes-config.yaml
+++ b/deploy/nats-event-bus/templates/nats-leafnodes-config.yaml
@@ -16,12 +16,19 @@ metadata:
     app.kubernetes.io/part-of: nats-event-bus
 data:
   leafnodes.conf: |
+{{- $serverTls := .Values.eventBus.cscLeafServerTLS | default dict }}
+{{- $remoteTls := .Values.eventBus.cpcLeafClientTLS | default dict }}
+{{- if and (eq .Values.eventBus.clusterType "csc") (not (empty $serverTls)) }}
+{{ include "nats-event-bus.natsConfBlock" (dict "name" "tls" "fields" $serverTls) | nindent 4 }}
+{{- end }}
 {{- if and (eq .Values.eventBus.clusterType "cpc") .Values.eventBus.cscEndpoint }}
     remotes: [
       {
         urls: [{{ .Values.eventBus.cscEndpoint | quote }}]
         nkey: $LEAF_USER_SEED
         account: CSC
+        {{- if not (empty $remoteTls) }}
+{{ include "nats-event-bus.natsConfBlock" (dict "name" "tls" "fields" $remoteTls) | nindent 8 }}{{- end }}
       }
     ]
 {{- end }}

--- a/deploy/nats-event-bus/values.yaml
+++ b/deploy/nats-event-bus/values.yaml
@@ -29,7 +29,28 @@ eventBus:
 
   # CSC endpoint for CPC leaf node connections
   # Required when clusterType is "cpc"
-  cscEndpoint: ""  # e.g., "nats://172.18.200.1:7422"
+  cscEndpoint: ""  # e.g., "nats://172.18.200.1:7422" or "tls://csc-gateway:7422"
+
+  # CSC accepting-side leafnode TLS
+  # The certificate files need to mounted into the nats container as volumes in the expected paths.
+  # https://docs.nats.io/running-a-nats-service/configuration/leafnodes/leafnode_conf
+  cscLeafServerTLS: {}
+    # Example (TLS-first handshake, NATS v2.10+):
+    # handshake_first: true
+    # cert_file: /etc/nats-certs/leafnodes/tls.crt
+    # key_file: /etc/nats-certs/leafnodes/tls.key
+    # ca_file: /etc/nats-certs/leafnodes/ca.crt
+    # verify: true
+
+  # CPC outbound remote leafnode TLS.
+  # The certificate files need to mounted into the nats container as volumes in the expected paths.
+  cpcLeafClientTLS: {}
+    # Example:
+    # handshake_first: true
+    # cert_file: /etc/nats-certs/leafnodes/tls.crt
+    # key_file: /etc/nats-certs/leafnodes/tls.key
+    # ca_file: /etc/nats-certs/leafnodes/ca.crt
+    # verify: true
 
   # List of CPC IDs that will connect to this CSC (CSC only)
   # Used to generate leaf node users for cross-cluster connections


### PR DESCRIPTION
Allow to configure TLS parameters in the accepting and outgoing side of leaf nodes in NATS.

## Description

This PR allow you to configure TLS between an accepting side and remote side for leaf nodes for a variety of scenarios. E.g.:
* TLS termination in a Gateway.
* TLS termination in the NATS server.

## Validation

* Helm charts were linted.
* Helm charts were rendered using example values.

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/dsx-exchange/blob/main/CONTRIBUTING.md).
- [X] Documentation updated, if needed.
- [] Tests or validation added/updated, if needed.
- [X] License headers are present on applicable source files.
- [x] Third-party license inventory updated, if dependencies changed.
- [x] Security-sensitive changes were reviewed privately before public disclosure.
- [x] My commits are signed off (`git commit -s`) per the DCO.
