### PR TITLE
fix: extraAccounts need additional NATS configuration when leaf nodes…

### DIFF
--- a/auth-callout/deploy/templates/deployment.yaml
+++ b/auth-callout/deploy/templates/deployment.yaml
@@ -66,6 +66,10 @@ spec:
               containerPort: {{ include "metrics.prometheusPort" . }}
               protocol: TCP
             {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             # Service and Application Configuration
             - name: AUTH_CALLOUT_SERVICE_NAME

--- a/auth-callout/deploy/values.yaml
+++ b/auth-callout/deploy/values.yaml
@@ -32,6 +32,13 @@ extraEnvs: {}
   #       name: secret-name
   #       key: secret-key
 
+# Additional envFrom entries, for loading groups of environment variables from
+# Secrets or ConfigMaps.
+extraEnvFrom: []
+  # - secretRef:
+  #     name: secret-name
+  #     optional: true
+
 # Additional volumes to be added to the pod
 extraVolumes:
   []

--- a/deploy/nats-event-bus/templates/_helpers.tpl
+++ b/deploy/nats-event-bus/templates/_helpers.tpl
@@ -15,6 +15,13 @@ CPC
 {{- end -}}
 
 {{/*
+extraAccountEnvName: Converts an extra account name into a stable env-var token.
+*/}}
+{{- define "nats-event-bus.extraAccountEnvName" -}}
+{{- regexReplaceAll "[^A-Z0-9]" (upper .) "_" -}}
+{{- end -}}
+
+{{/*
 natsConfFields: Renders a NATS configuration block body from a flat map.
 Strings are quoted; booleans and numbers are unquoted.
 */}}

--- a/deploy/nats-event-bus/templates/auth-callout-permissions.yaml
+++ b/deploy/nats-event-bus/templates/auth-callout-permissions.yaml
@@ -20,6 +20,22 @@ Pubkeys use ${ENV_VAR} syntax for runtime expansion from secrets.
 {{- range .Values.eventBus.cpcIds }}
 {{- $autoNkeys = set $autoNkeys (printf "leaf-cpc-%s" .) (dict "public_key" (printf "${NKEY_LEAF_CPC_%s_PUBKEY}" .) "account" "CSC") }}
 {{- end }}
+{{- range $accountName, $config := .Values.eventBus.extraAccounts }}
+{{- $enabled := true -}}
+{{- if hasKey $config "enabled" -}}
+{{- $enabled = $config.enabled -}}
+{{- end -}}
+{{- $leaf := get $config "leaf" | default dict -}}
+{{- if and $enabled ($leaf.enabled | default false) }}
+{{- $accountEnvName := include "nats-event-bus.extraAccountEnvName" $accountName -}}
+{{- $pubkeyEnvPrefix := get $leaf "pubkeyEnvPrefix" | default (printf "NKEY_LEAF_%s_CPC" $accountEnvName) -}}
+{{- range $.Values.eventBus.cpcIds }}
+{{- $cpcId := toString . -}}
+{{- $pubkeyEnv := printf "%s_%s_PUBKEY" $pubkeyEnvPrefix $cpcId -}}
+{{- $autoNkeys = set $autoNkeys (printf "leaf-%s-cpc-%s" (lower $accountEnvName) $cpcId) (dict "public_key" (printf "${%s}" $pubkeyEnv) "account" $accountName) }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- $userNkeys := .Values.eventBus.auth.permissions.nkey | default dict -}}
 {{- $mergedNkeys := merge $userNkeys $autoNkeys -}}

--- a/deploy/nats-event-bus/templates/nats-accounts-config.yaml
+++ b/deploy/nats-event-bus/templates/nats-accounts-config.yaml
@@ -22,11 +22,19 @@ data:
       jetstream: true
     }
   {{- range $name, $config := $.Values.eventBus.extraAccounts }}
+    {{- $enabled := true -}}
+    {{- if hasKey $config "enabled" -}}
+    {{- $enabled = $config.enabled -}}
+    {{- end -}}
+    {{- if $enabled }}
     {{ $name }} {
       {{- range $key, $value := $config }}
+      {{- if and (ne $key "enabled") (ne $key "leaf") }}
       {{ $key }}: {{ $value }}
       {{- end }}
+      {{- end }}
     }
+    {{- end }}
   {{- end }}
 {{ else if eq .Values.eventBus.clusterType "cpc" }}
 {{- $clusterId := .Values.eventBus.clusterId -}}
@@ -79,16 +87,22 @@ data:
       ]
     }
   {{- range $name, $config := $.Values.eventBus.extraAccounts }}
+    {{- $enabled := true -}}
+    {{- if hasKey $config "enabled" -}}
+    {{- $enabled = $config.enabled -}}
+    {{- end -}}
+    {{- if $enabled }}
     {{ $name }} {
       jetstream: false
       mappings: {
         "$JS.API.>": "$JS.CSC.API.>"
       }
       {{- range $key, $value := $config }}
-      {{- if ne $key "jetstream" }}
+      {{- if and (ne $key "jetstream") (ne $key "enabled") (ne $key "leaf") }}
       {{ $key }}: {{ $value }}
       {{- end }}
       {{- end }}
     }
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/deploy/nats-event-bus/templates/nats-leafnodes-config.yaml
+++ b/deploy/nats-event-bus/templates/nats-leafnodes-config.yaml
@@ -30,5 +30,24 @@ data:
         {{- if not (empty $remoteTls) }}
 {{ include "nats-event-bus.natsConfBlock" (dict "name" "tls" "fields" $remoteTls) | nindent 8 }}{{- end }}
       }
+{{- range $name, $config := $.Values.eventBus.extraAccounts }}
+{{- $enabled := true -}}
+{{- if hasKey $config "enabled" -}}
+{{- $enabled = $config.enabled -}}
+{{- end -}}
+{{- $leaf := get $config "leaf" | default dict -}}
+{{- if and $enabled ($leaf.enabled | default false) }}
+{{- $accountEnvName := include "nats-event-bus.extraAccountEnvName" $name -}}
+{{- $seedEnv := get $leaf "seedEnv" | default (printf "LEAF_%s_USER_SEED" $accountEnvName) -}}
+{{ printf "\n" }}
+      {
+        urls: [{{ $.Values.eventBus.cscEndpoint | quote }}]
+        nkey: ${{ $seedEnv }}
+        account: {{ $name | quote }}
+        {{- if not (empty $remoteTls) }}
+{{ include "nats-event-bus.natsConfBlock" (dict "name" "tls" "fields" $remoteTls) | nindent 8 }}{{- end }}
+      }
+{{- end }}
+{{- end }}
     ]
 {{- end }}

--- a/deploy/nats-event-bus/values.yaml
+++ b/deploy/nats-event-bus/values.yaml
@@ -69,13 +69,44 @@ eventBus:
   mtls:
     enabled: true
 
-  # Extra NATS accounts
-  # Each account gets automatic leaf setup on CPCs with JetStream domain mapping
+  # Extra NATS accounts.
+  #
+  # On CSC clusters, extra accounts are local accounts and may enable
+  # JetStream. On CPC clusters, extra accounts keep local JetStream disabled and
+  # route JetStream API calls to the matching account in CSC.
+  #
+  # Set leaf.enabled=true when an extra account needs its own CPC-to-CSC leaf
+  # connection. The chart then renders:
+  #   - a CPC leaf remote for that account
+  #   - a CSC auth-callout NKey permission entry for that account
+  #
+  # The chart does not create the NKey material or Kubernetes Secrets. Those
+  # must already exist in the namespace.
+  #
+  # For an account named LaunchLayer and CPC ID 1, create:
+  #
+  #   CPC/datahall cluster:
+  #     Secret name: nats-extra-account-leaf-seeds
+  #     Secret key:  LEAF_LAUNCHLAYER_USER_SEED
+  #     Value:       private NATS NKey seed for the LaunchLayer leaf
+  #
+  #   CSC cluster:
+  #     Secret name: nats-extra-account-leaf-pubkeys
+  #     Secret key:  NKEY_LEAF_LAUNCHLAYER_CPC_1_PUBKEY
+  #     Value:       matching public NATS NKey for the LaunchLayer leaf
+  #
+  # These secret names are fixed by this chart.
   extraAccounts: {}
     # Example:
     # LaunchLayer:
     #   enabled: true
-    #   jetstream: true  # CSC only, CPCs always have JetStream off and use the CSC's jetstream domain
+    #   jetstream: true  # CSC only; CPCs always use CSC's JetStream domain
+    #   leaf:
+    #     enabled: true
+    #     # Defaults shown here match the standard secret keys above and do not need to be overridden.
+    #     # Only override if you need to use a different secret key.
+    #     seedEnv: LEAF_LAUNCHLAYER_USER_SEED
+    #     pubkeyEnvPrefix: NKEY_LEAF_LAUNCHLAYER_CPC
     # Kiwi:
     #   enabled: true
 
@@ -115,6 +146,8 @@ eventBus:
   # Cross-Cluster Leaf Connections:
   #   nats-leaf-csc          seed                CPC to CSC leaf (CPC clusters only)
   #   nats-leaf-cpc-{id}     pubkey              CPC leaf users (CSC only, via auth-callout.extraEnvs)
+  #   nats-extra-account-leaf-seeds              Extra-account CPC leaf seeds
+  #   nats-extra-account-leaf-pubkeys            Extra-account CSC leaf pubkeys
   #
   # YAML anchors for secretKeyRef values used by pod specs:
   nkeyRefs:
@@ -377,6 +410,11 @@ nats:
           configMapKeyRef:
             name: nats-env-config
             key: NATS_JS_DOMAIN
+    merge:
+      envFrom:
+        - secretRef:
+            name: nats-extra-account-leaf-seeds
+            optional: true
     patch:
     - op: add
       path: /volumeMounts/-
@@ -585,10 +623,7 @@ auth-callout:
   # Common auth-callout env vars.
   # CSC clusters with eventBus.cpcIds must also provide one
   # NKEY_LEAF_CPC_{N}_PUBKEY entry per CPC in auth-callout.extraEnvs.
-  # Example: cpcIds: ["1", "2"] requires NKEY_LEAF_CPC_1_PUBKEY
-  # and NKEY_LEAF_CPC_2_PUBKEY.
-  # The chart validates this so leaf federation fails at render time instead
-  # of failing later with NATS Authorization Violation.
+  # Extra-account leaf pubkeys are loaded from nats-extra-account-leaf-pubkeys.
   extraEnvs:
     AUTH_CALLOUT_NATS_NKEY_SEED: *authCalloutNkeySeed
     AUTH_CALLOUT_NATS_ISSUER_SEED: *authCalloutIssuerSeed
@@ -598,6 +633,10 @@ auth-callout:
     NKEY_MTLS_AUTHX_LEAF_PUBKEY: *mtlsAuthxLeafPubkey
     NKEY_MTLS_SYS_LEAF_PUBKEY: *mtlsSysLeafPubkey
     NKEY_SURVEYOR_PUBKEY: *surveyorNkeyPubkey
+  extraEnvFrom:
+    - secretRef:
+        name: nats-extra-account-leaf-pubkeys
+        optional: true
 
 # Surveyor configuration - Prometheus metrics exporter for NATS monitoring
 # See https://github.com/nats-io/nats-surveyor for metrics reference


### PR DESCRIPTION
## Description

Fixes extra NATS accounts, such as `LaunchLayer`, when they need to use JetStream through a CPC-to-CSC leaf connection.

Previously extra accounts on CPC clusters rendered with local JetStream disabled and `$JS.API.>` mapped to the CSC JetStream domain, but they did not get the matching leaf remote or CSC auth-callout NKey permission entry. That meant clients authenticated into an extra account could connect successfully, but JetStream API requests had no reachable responder.

This change adds optional `extraAccounts.<account>.leaf.enabled` support so the chart can render:

- a CPC leaf remote for the extra account
- a CSC auth-callout NKey permission entry for that leaf user
- optional fixed `envFrom` secret loading for extra-account leaf seeds/pubkeys