### PR TITLE
DO NOT MERGE — smoke-test BuildKit mirror fix (NVIDIA/dsx-github-actions#48)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,17 @@ jobs:
     runs-on: linux-amd64-cpu4
     steps:
       - uses: actions/checkout@v4
+      - name: SMOKE-TEST — verify buildkitd mirror config is present on runner
+        run: |
+          set -euo pipefail
+          echo "::group::/etc/buildkit/buildkitd.toml"
+          if [[ -f /etc/buildkit/buildkitd.toml ]]; then
+            cat /etc/buildkit/buildkitd.toml
+          else
+            echo "MISSING: /etc/buildkit/buildkitd.toml not found on runner"
+            exit 1
+          fi
+          echo "::endgroup::"
       - uses: NVIDIA/dsx-github-actions/.github/actions/docker-build@480b123eed6fa49a1fe23ea0f963ca9f0d8b7752 # SMOKE-TEST: fix/buildkit-registry-mirror (revert to v1.16.0 tag before merge)
         with:
           image: dsx-exchange-auth-callout
@@ -172,6 +183,17 @@ jobs:
     runs-on: linux-amd64-cpu4
     steps:
       - uses: actions/checkout@v4
+      - name: SMOKE-TEST — verify buildkitd mirror config is present on runner
+        run: |
+          set -euo pipefail
+          echo "::group::/etc/buildkit/buildkitd.toml"
+          if [[ -f /etc/buildkit/buildkitd.toml ]]; then
+            cat /etc/buildkit/buildkitd.toml
+          else
+            echo "MISSING: /etc/buildkit/buildkitd.toml not found on runner"
+            exit 1
+          fi
+          echo "::endgroup::"
       - uses: NVIDIA/dsx-github-actions/.github/actions/docker-build@480b123eed6fa49a1fe23ea0f963ca9f0d8b7752 # SMOKE-TEST: fix/buildkit-registry-mirror (revert to v1.16.0 tag before merge)
         with:
           image: dsx-exchange-auth-callout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
     runs-on: linux-amd64-cpu4
     steps:
       - uses: actions/checkout@v4
-      - uses: NVIDIA/dsx-github-actions/.github/actions/docker-build@739847ddf00fda38916504ef84e1f504eac3158f # v1.16.0
+      - uses: NVIDIA/dsx-github-actions/.github/actions/docker-build@480b123eed6fa49a1fe23ea0f963ca9f0d8b7752 # SMOKE-TEST: fix/buildkit-registry-mirror (revert to v1.16.0 tag before merge)
         with:
           image: dsx-exchange-auth-callout
           tags: ci-validation
@@ -172,7 +172,7 @@ jobs:
     runs-on: linux-amd64-cpu4
     steps:
       - uses: actions/checkout@v4
-      - uses: NVIDIA/dsx-github-actions/.github/actions/docker-build@739847ddf00fda38916504ef84e1f504eac3158f # v1.16.0
+      - uses: NVIDIA/dsx-github-actions/.github/actions/docker-build@480b123eed6fa49a1fe23ea0f963ca9f0d8b7752 # SMOKE-TEST: fix/buildkit-registry-mirror (revert to v1.16.0 tag before merge)
         with:
           image: dsx-exchange-auth-callout
           tags: scan-validation


### PR DESCRIPTION
## Purpose — DO NOT MERGE

Temporary pin of the `docker-build` composite action to the head of [NVIDIA/dsx-github-actions#48](https://github.com/NVIDIA/dsx-github-actions/pull/48) (`fix/buildkit-registry-mirror`, commit `480b123eed6fa49a1fe23ea0f963ca9f0d8b7752`) so we can verify the BuildKit registry-mirror fix end-to-end on the exact build that originally failed.

Also adds a small verification step ahead of each `docker-build` call that dumps `/etc/buildkit/buildkitd.toml` from the runner into the job log. Reviewers can read that block directly to confirm the mirror is configured to point at `dockerhub.nvidia.com`.

Tracks: nvbug 6225636.

## What this validates

The `Docker Build (auth-callout)` job pulls `golang:1.25.5` as the builder base image. Previously that pull went to `registry-1.docker.io` and hit the Docker Hub unauthenticated rate limit (`429 toomanyrequests`). With the fix in #48, `docker/setup-buildx-action` is given `buildkitd-config: /etc/buildkit/buildkitd.toml`, which routes BuildKit pulls through `dockerhub.nvidia.com` (NVIDIA's Artifactory pull-through cache) instead.

Two signals to confirm in the job logs:

1. **The verification step** (`SMOKE-TEST — verify buildkitd mirror config is present on runner`) prints the actual TOML contents. Look for `[registry."docker.io"]` with `mirrors = ["dockerhub.nvidia.com"]`.
2. **The build step itself** resolves `golang:1.25.5` cleanly, no `429`. This is the regression-passing signal.

The `Container Scan (auth-callout)` job exercises the composite action a second time on a separate runner, so a green run there also verifies the config is available across runner instances.

## Rollback

Close this PR without merging. After NVIDIA/dsx-github-actions#48 merges and a new tag (likely `v1.17.0`) is cut, a separate adoption PR will bump both `uses:` lines to the new tag and drop the verification step.

## Test plan

- [ ] `copy-pr-bot` vetted so workflows can run.
- [ ] `SMOKE-TEST — verify buildkitd mirror config is present on runner` step in `Docker Build (auth-callout)` succeeds and shows `mirrors = ["dockerhub.nvidia.com"]`.
- [ ] `Docker Build (auth-callout)` job succeeds end-to-end on `golang:1.25.5`.
- [ ] Same two checks pass on `Container Scan (auth-callout)`.