### PR TITLE
chore(deps): bump dsx-github-actions pins to v1.16.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,14 +31,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: NVIDIA/dsx-github-actions/.github/actions/commitlint@739847ddf00fda38916504ef84e1f504eac3158f # v1.16.0
+      - uses: NVIDIA/dsx-github-actions/.github/actions/commitlint@07b465c2147fcbda4836cb869263577ea4719273 # v1.16.1
 
   license-headers:
     name: License Headers
     runs-on: linux-amd64-cpu4
     steps:
       - uses: actions/checkout@v4
-      - uses: NVIDIA/dsx-github-actions/.github/actions/license-headers@739847ddf00fda38916504ef84e1f504eac3158f # v1.16.0
+      - uses: NVIDIA/dsx-github-actions/.github/actions/license-headers@07b465c2147fcbda4836cb869263577ea4719273 # v1.16.1
         with:
           license: apache
           copyright-holder: "NVIDIA CORPORATION & AFFILIATES. All rights reserved."
@@ -52,7 +52,7 @@ jobs:
     runs-on: linux-amd64-cpu4
     steps:
       - uses: actions/checkout@v4
-      - uses: NVIDIA/dsx-github-actions/.github/actions/go-lint@739847ddf00fda38916504ef84e1f504eac3158f # v1.16.0
+      - uses: NVIDIA/dsx-github-actions/.github/actions/go-lint@07b465c2147fcbda4836cb869263577ea4719273 # v1.16.1
         with:
           go-version: "1.25.5"
           go-flags: "-mod=vendor"
@@ -63,7 +63,7 @@ jobs:
     runs-on: linux-amd64-cpu4
     steps:
       - uses: actions/checkout@v4
-      - uses: NVIDIA/dsx-github-actions/.github/actions/go-test@739847ddf00fda38916504ef84e1f504eac3158f # v1.16.0
+      - uses: NVIDIA/dsx-github-actions/.github/actions/go-test@07b465c2147fcbda4836cb869263577ea4719273 # v1.16.1
         with:
           go-version: "1.25.5"
           go-flags: "-mod=vendor"
@@ -121,7 +121,7 @@ jobs:
     runs-on: linux-amd64-cpu4
     steps:
       - uses: actions/checkout@v4
-      - uses: NVIDIA/dsx-github-actions/.github/actions/docker-build@739847ddf00fda38916504ef84e1f504eac3158f # v1.16.0
+      - uses: NVIDIA/dsx-github-actions/.github/actions/docker-build@07b465c2147fcbda4836cb869263577ea4719273 # v1.16.1
         with:
           image: dsx-exchange-auth-callout
           tags: ci-validation
@@ -144,7 +144,7 @@ jobs:
         with:
           go-version: "1.25.5"
           cache: false
-      - uses: NVIDIA/dsx-github-actions/.github/actions/codeql-scan@739847ddf00fda38916504ef84e1f504eac3158f # v1.16.0
+      - uses: NVIDIA/dsx-github-actions/.github/actions/codeql-scan@07b465c2147fcbda4836cb869263577ea4719273 # v1.16.1
         with:
           languages: go
           upload-sarif: "false"
@@ -160,7 +160,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: NVIDIA/dsx-github-actions/.github/actions/trufflehog-scan@739847ddf00fda38916504ef84e1f504eac3158f # v1.16.0
+      - uses: NVIDIA/dsx-github-actions/.github/actions/trufflehog-scan@07b465c2147fcbda4836cb869263577ea4719273 # v1.16.1
         with:
           post-pr-comment: "true"
           fail-on-findings: "true"
@@ -172,7 +172,7 @@ jobs:
     runs-on: linux-amd64-cpu4
     steps:
       - uses: actions/checkout@v4
-      - uses: NVIDIA/dsx-github-actions/.github/actions/docker-build@739847ddf00fda38916504ef84e1f504eac3158f # v1.16.0
+      - uses: NVIDIA/dsx-github-actions/.github/actions/docker-build@07b465c2147fcbda4836cb869263577ea4719273 # v1.16.1
         with:
           image: dsx-exchange-auth-callout
           tags: scan-validation
@@ -180,7 +180,7 @@ jobs:
           dockerfile: auth-callout/build/package/Dockerfile
           platforms: linux/amd64
           push: "false"
-      - uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan@739847ddf00fda38916504ef84e1f504eac3158f # v1.16.0
+      - uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan@07b465c2147fcbda4836cb869263577ea4719273 # v1.16.1
         with:
           image: dsx-exchange-auth-callout:scan-validation
 
@@ -189,7 +189,7 @@ jobs:
     runs-on: linux-amd64-cpu4
     steps:
       - uses: actions/checkout@v4
-      - uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@739847ddf00fda38916504ef84e1f504eac3158f # v1.16.0
+      - uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@07b465c2147fcbda4836cb869263577ea4719273 # v1.16.1
         with:
           chart-path: auth-callout/deploy
 
@@ -198,7 +198,7 @@ jobs:
     runs-on: linux-amd64-cpu4
     steps:
       - uses: actions/checkout@v4
-      - uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@739847ddf00fda38916504ef84e1f504eac3158f # v1.16.0
+      - uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@07b465c2147fcbda4836cb869263577ea4719273 # v1.16.1
         with:
           chart-path: deploy/nats-event-bus
           lint: "true"
@@ -229,7 +229,7 @@ jobs:
       CI_STATUS: ${{ contains(needs.*.result, 'failure') && 'FAILED' || 'PASSED' }}
       RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
-      - uses: NVIDIA/dsx-github-actions/.github/actions/slack-notify@739847ddf00fda38916504ef84e1f504eac3158f # v1.16.0
+      - uses: NVIDIA/dsx-github-actions/.github/actions/slack-notify@07b465c2147fcbda4836cb869263577ea4719273 # v1.16.1
         with:
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: C09VC8R4E92

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - uses: NVIDIA/dsx-github-actions/.github/actions/semantic-release@739847ddf00fda38916504ef84e1f504eac3158f # v1.16.0
+      - uses: NVIDIA/dsx-github-actions/.github/actions/semantic-release@07b465c2147fcbda4836cb869263577ea4719273 # v1.16.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-plugins: conventional-changelog-conventionalcommits

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,4 +18,4 @@ jobs:
     name: Mark Stale Issues and PRs
     runs-on: linux-amd64-cpu4
     steps:
-      - uses: NVIDIA/dsx-github-actions/.github/actions/stale-check@739847ddf00fda38916504ef84e1f504eac3158f # v1.16.0
+      - uses: NVIDIA/dsx-github-actions/.github/actions/stale-check@07b465c2147fcbda4836cb869263577ea4719273 # v1.16.1


### PR DESCRIPTION
## Summary

Adopts [NVIDIA/dsx-github-actions v1.16.1](https://github.com/NVIDIA/dsx-github-actions/releases/tag/v1.16.1) by bumping all pinned references in this repo. The load-bearing change is in the two `docker-build` action references in \`ci.yml\` — v1.16.1 configures BuildKit on the \`nv-gha-runners\` to route Docker Hub pulls through \`dockerhub.nvidia.com\` (NVIDIA's Artifactory pull-through cache), eliminating the anonymous rate-limit failures (\`429 toomanyrequests\`) that previously broke the \`Docker Build (auth-callout)\` and \`Container Scan (auth-callout)\` jobs.

Reference: nvbug 6225636.

## Diff

14 pin updates from \`v1.16.0\` (\`739847d\`) to \`v1.16.1\` (\`07b465c\`):

| File | Pin count | Notes |
|---|---|---|
| \`.github/workflows/ci.yml\` | 12 | Includes the two **docker-build** pins (load-bearing) plus 10 other actions bumped for repo-wide consistency. |
| \`.github/workflows/release.yml\` | 1 | \`semantic-release\` — no functional change. |
| \`.github/workflows/stale.yml\` | 1 | \`stale-check\` — no functional change. |

Only the two \`docker-build\` references gain new behavior in v1.16.1. The other 12 pins point at action source trees that are identical between v1.16.0 and v1.16.1.

## Why bump the consistency pins too

This repo uses a single coordinated pin per release across all \`dsx-github-actions\` references. Keeping one action ahead of the others would split the version surface and complicate future bumps. The diff stays small (one SHA, search-and-replace), the review burden stays low.

## What v1.16.1 changes in the docker-build action

A single line was added to the \`Set up Docker Buildx\` step:

```
- name: Set up Docker Buildx
  uses: docker/setup-buildx-action@v3
  with:
    buildkitd-config: /etc/buildkit/buildkitd.toml   # ← new
```

That config file is pre-populated on \`nv-gha-runners\` and points BuildKit at \`dockerhub.nvidia.com\`. The change is documented as the NVIDIA GHA platform team's best practice: https://docs.gha-runners.nvidia.com/platform/best-practices/#use-docker-cache-for-buildkit

## Test plan

- [x] CI on this PR — specifically \`Docker Build (auth-callout)\` and \`Container Scan (auth-callout)\` jobs — succeed where they previously failed on \`golang:1.25.5\`.
- [x] BuildKit logs reference \`dockerhub.nvidia.com\` (visible in the \`Set up Docker Buildx\` step output).
- [x] Other CI jobs (commitlint, license-headers, go-lint, go-test, codeql-scan, trufflehog-scan, security-container-scan, helm-validate) stay green — confirming the consistency-pin bumps don't regress anything.