### PR TITLE
docs: add integrator quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ cd dsx-exchange
 make check
 ```
 
-If you already have a DSX Exchange broker and only need to publish your first
-message, start with the [Integrator Quickstart](docs/integrator-quickstart.md).
+If you already have a DSX Exchange broker and need to build or test an MQTT
+integration application, start with the
+[Integrator Quickstart](docs/integrator-quickstart.md).
 
 For local end-to-end validation, create the Kind environment and deploy NATS:
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ cd dsx-exchange
 make check
 ```
 
+If you already have a DSX Exchange broker and only need to publish your first
+message, start with the [Integrator Quickstart](docs/integrator-quickstart.md).
+
 For local end-to-end validation, create the Kind environment and deploy NATS:
 
 ```bash

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -806,7 +806,7 @@ kubectl get pods -n dsx
 
 # Test MQTT connectivity
 mqttx pub -h $GATEWAY_IP -p 1883 -t test/topic -m "hello" \
-  -u "oauth2" -P "$ACCESS_TOKEN" -V 3.1.1
+  -u "oauthtoken" -P "$ACCESS_TOKEN" -V 3.1.1
 
 # Or test NATS connectivity
 nats pub test.topic "hello" --server nats://$GATEWAY_IP:4222

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -36,7 +36,7 @@ sequenceDiagram
 
 ### OAuth2 (JWT/JWKS)
 
-Clients connect with a username of `oauth2token` and an access token as the password. The auth-callout validates the token against the OIDC provider's JWKS endpoint and matches the token's `azp` (authorized party) or `subject` claim to a permissions entry.
+Clients connect with a username of `oauthtoken` and an access token as the password. The auth-callout validates the token against the OIDC provider's JWKS endpoint and matches the token's `azp` (authorized party) or `subject` claim to a permissions entry.
 
 Configure the JWKS endpoint and issuer in the Helm values:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -192,7 +192,7 @@ kubectl get pods -n dsx
 
 # Test MQTT connectivity
 mqttx pub -h $GATEWAY_IP -p 1883 -t test/topic -m "hello" \
-  -u "oauth2token" -P "$ACCESS_TOKEN" -V 3.1.1
+  -u "oauthtoken" -P "$ACCESS_TOKEN" -V 3.1.1
 
 # Test NATS connectivity
 nats pub test.topic "hello" --server nats://$GATEWAY_IP:4222

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,9 @@ make -C local validate-nats     # Verify connectivity
 
 See `local/README.md` for the full set of evaluation targets including functional tests, performance benchmarks, and MQTT client tooling.
 
-If you already have access to a running broker and only need to publish your first message, use the [Integrator Quickstart](integrator-quickstart.md) instead of this operator deployment flow.
+If you already have access to a running broker and need to build or test an MQTT
+integration application, use the [Integrator Quickstart](integrator-quickstart.md)
+instead of this operator deployment flow.
 
 The rest of this page covers the production deployment path.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,6 +16,8 @@ make -C local validate-nats     # Verify connectivity
 
 See `local/README.md` for the full set of evaluation targets including functional tests, performance benchmarks, and MQTT client tooling.
 
+If you already have access to a running broker and only need to publish your first message, use the [Integrator Quickstart](integrator-quickstart.md) instead of this operator deployment flow.
+
 The rest of this page covers the production deployment path.
 
 ## Prerequisites

--- a/docs/integrator-quickstart.md
+++ b/docs/integrator-quickstart.md
@@ -1,0 +1,69 @@
+# Integrator Quickstart
+
+Use this guide when an event bus broker already exists and you only need to prove that your client can publish and receive its first MQTT message. It does not cover installing the broker; see [Deployment](getting-started.md) for operator setup.
+
+## Prerequisites
+
+- MQTT client tooling such as `mqttx`.
+- Network access to the broker's MQTT listener.
+- A noauth permissions entry that allows publishing and subscribing on `test.>`.
+  This is the NATS subject permission for MQTT topic `test/hello`; the broker maps MQTT `/` topic separators to NATS `.` subjects.
+
+The local evaluation CSC broker provides that noauth path after the event bus is deployed. For production brokers, confirm the configured authentication mode and topic permissions with the operator. See [Authentication](authentication.md) for OAuth2, mTLS, NKey, and noauth configuration.
+
+## Connect to the Broker
+
+Set the broker endpoint you received from the operator:
+
+```bash
+export DSX_MQTT_HOST=broker.example.com
+export DSX_MQTT_PORT=1883
+```
+
+If you are using the local evaluation environment and it is already deployed, start the broker port-forwards in one terminal and run the quickstart commands in the shell it launches. To create the local broker first, use the [Deployment](getting-started.md) evaluation install.
+
+```bash
+cd local
+./infra/scripts/with-gateway-port-forwards.sh sh
+export DSX_MQTT_HOST=127.0.0.1
+export DSX_MQTT_PORT=11883
+```
+
+## Subscribe
+
+Open a terminal and subscribe before publishing so you can see the message arrive:
+
+```bash
+mqttx sub \
+  -h "${DSX_MQTT_HOST}" \
+  -p "${DSX_MQTT_PORT}" \
+  -t "test/hello" \
+  -V 3.1.1
+```
+
+Leave this command running.
+
+## Publish
+
+Open a second terminal with the same `DSX_MQTT_HOST` and `DSX_MQTT_PORT` values, then publish one message:
+
+```bash
+mqttx pub \
+  -h "${DSX_MQTT_HOST}" \
+  -p "${DSX_MQTT_PORT}" \
+  -t "test/hello" \
+  -m '{"message":"hello from dsx exchange"}' \
+  -V 3.1.1
+```
+
+The subscriber terminal should print the payload:
+
+```json
+{"message":"hello from dsx exchange"}
+```
+
+## Next Steps
+
+- Replace `test/hello` with a topic allowed by your integration's permissions.
+- Use the schema pages to choose the correct topic and payload for your domain.
+- Switch from noauth to the broker's required authentication mode before production use.

--- a/docs/integrator-quickstart.md
+++ b/docs/integrator-quickstart.md
@@ -35,13 +35,8 @@ configuration.
 
 ## Connection Settings
 
-Set the broker endpoint and topic you received from the operator:
-
-```bash
-export DSX_MQTT_HOST=broker.example.com
-export DSX_MQTT_PORT=1883
-export DSX_MQTT_TOPIC=test/hello
-```
+Set the broker endpoint, authentication material, and topic configuration you
+received from the operator in your application configuration.
 
 If you are using the local evaluation environment and it is already deployed,
 start the broker port forwards in one terminal and leave that terminal open
@@ -63,13 +58,8 @@ export DSX_MQTT_PORT=11883
 export DSX_MQTT_TOPIC=test/hello
 ```
 
-For OAuth2 clients, pass the token through your SDK's username/password connect
-options:
-
-```bash
-export DSX_MQTT_USERNAME=oauth2token
-export DSX_MQTT_PASSWORD="<access-token>"
-```
+For OAuth2 clients, set the MQTT username to `oauthtoken` and pass the access
+token as the MQTT password.
 
 For mTLS clients, configure the SDK's TLS options with the CA certificate, client
 certificate, and client key supplied by the operator.

--- a/docs/integrator-quickstart.md
+++ b/docs/integrator-quickstart.md
@@ -1,62 +1,220 @@
 # Integrator Quickstart
 
-Use this guide when an event bus broker already exists and you only need to prove that your client can publish and receive its first MQTT message. It does not cover installing the broker; see [Deployment](getting-started.md) for operator setup.
+Use this guide to start writing an integration application that connects to an
+existing DSX Exchange MQTT broker. DSX Exchange uses standard MQTT 3.1.1, so you
+do not need a DSX-specific client library. Build your integration with an
+existing MQTT SDK for your runtime, then use the broker endpoint, authentication
+material, topics, and schemas supplied by the DSX Exchange operator.
+
+The examples below show both application level SDK usage and manual broker
+interaction. The standalone MQTT CLI commands are included to help debug
+connectivity, credentials, and topic permissions while you develop the
+application. They are not the recommended shape for a production integration.
+
+This page assumes a broker already exists. For broker installation and operator
+setup, see [Deployment](getting-started.md).
 
 ## Prerequisites
 
-- MQTT client tooling such as `mqttx`.
+- Broker host, port, and authentication details from the operator.
+- Topic permissions for the messages your integration will publish or subscribe.
+- An MQTT SDK for the language or platform your application uses.
+- Optional debug tooling such as `mqttx` or `mosquitto-clients`.
 - Network access to the broker's MQTT listener.
-- A noauth permissions entry that allows publishing and subscribing on `test.>`.
-  This is the NATS subject permission for MQTT topic `test/hello`; the broker maps MQTT `/` topic separators to NATS `.` subjects.
 
-The local evaluation CSC broker provides that noauth path after the event bus is deployed. For production brokers, confirm the configured authentication mode and topic permissions with the operator. See [Authentication](authentication.md) for OAuth2, mTLS, NKey, and noauth configuration.
+The local evaluation CSC broker provides a noauth debug path that allows
+publishing and subscribing on `test.>`. This is the NATS subject permission for
+MQTT topic `test/hello`. The broker maps MQTT `/` topic separators to NATS `.`
+subjects.
 
-## Connect to the Broker
+For production brokers, confirm the configured authentication mode and topic
+permissions with the operator. Most software integrations should use OAuth2.
+BMS, OT, and device integrations commonly use mTLS with client certificates.
+See [Authentication](authentication.md) for OAuth2, mTLS, NKey, and noauth
+configuration.
 
-Set the broker endpoint you received from the operator:
+## Connection Settings
+
+Set the broker endpoint and topic you received from the operator:
 
 ```bash
 export DSX_MQTT_HOST=broker.example.com
 export DSX_MQTT_PORT=1883
+export DSX_MQTT_TOPIC=test/hello
 ```
 
-If you are using the local evaluation environment and it is already deployed, start the broker port-forwards in one terminal and run the quickstart commands in the shell it launches. To create the local broker first, use the [Deployment](getting-started.md) evaluation install.
+If you are using the local evaluation environment and it is already deployed,
+start the broker port forwards in one terminal and leave that terminal open
+while you test. The script starts `kubectl port-forward` processes, then opens a
+shell. The port forwards stop when you exit that shell. To create the local
+broker first, use the [Deployment](getting-started.md) evaluation install.
 
 ```bash
 cd local
 ./infra/scripts/with-gateway-port-forwards.sh sh
-export DSX_MQTT_HOST=127.0.0.1
-export DSX_MQTT_PORT=11883
 ```
 
-## Subscribe
+In the shell opened by that script, or in another terminal while that shell stays
+open, use the local CSC broker endpoint:
 
-Open a terminal and subscribe before publishing so you can see the message arrive:
+```bash
+export DSX_MQTT_HOST=127.0.0.1
+export DSX_MQTT_PORT=11883
+export DSX_MQTT_TOPIC=test/hello
+```
+
+For OAuth2 clients, pass the token through your SDK's username/password connect
+options:
+
+```bash
+export DSX_MQTT_USERNAME=oauth2token
+export DSX_MQTT_PASSWORD="<access-token>"
+```
+
+For mTLS clients, configure the SDK's TLS options with the CA certificate, client
+certificate, and client key supplied by the operator.
+
+## Choose an MQTT SDK
+
+Use the MQTT library that best fits the application you are already building.
+Common options include:
+
+| Runtime | SDK examples |
+|---------|--------------|
+| Go | Eclipse Paho Go (`github.com/eclipse/paho.mqtt.golang`) |
+| Python | Eclipse Paho Python (`paho-mqtt`) |
+| Node.js | MQTT.js (`mqtt`) |
+| Java | Eclipse Paho Java |
+| C/C++ | Eclipse Paho C/C++ or libmosquitto |
+
+All SDKs follow the same basic flow:
+
+1. Load broker host, port, topic, and auth material from configuration.
+2. Create an MQTT 3.1.1 client with a stable client ID.
+3. Connect with the authentication mode assigned by the operator.
+4. Subscribe, publish, or both, using topics allowed by your permissions.
+5. Handle reconnects, publish acknowledgements, and application shutdown.
+
+## Python SDK Sample
+
+This sample uses the Python Paho MQTT SDK to publish one debug message. Replace
+`DSX_MQTT_TOPIC` and the payload with the topic and schema payload for your
+integration.
+
+```bash
+python3 -m pip install paho-mqtt
+```
+
+```python
+# dsx_publish.py
+import json
+import os
+
+import paho.mqtt.client as mqtt
+
+
+host = os.environ["DSX_MQTT_HOST"]
+port = int(os.getenv("DSX_MQTT_PORT", "1883"))
+topic = os.getenv("DSX_MQTT_TOPIC", "test/hello")
+
+client = mqtt.Client(
+    mqtt.CallbackAPIVersion.VERSION2,
+    client_id=os.getenv("DSX_MQTT_CLIENT_ID", "dsx-quickstart-publisher"),
+    protocol=mqtt.MQTTv311,
+)
+
+username = os.getenv("DSX_MQTT_USERNAME")
+password = os.getenv("DSX_MQTT_PASSWORD")
+if username or password:
+    client.username_pw_set(username, password)
+
+ca_file = os.getenv("DSX_MQTT_CA")
+cert_file = os.getenv("DSX_MQTT_CERT")
+key_file = os.getenv("DSX_MQTT_KEY")
+if ca_file or cert_file or key_file:
+    client.tls_set(ca_certs=ca_file, certfile=cert_file, keyfile=key_file)
+
+payload = json.dumps({"message": "hello from dsx exchange"})
+
+client.connect(host, port, keepalive=30)
+client.loop_start()
+result = client.publish(topic, payload, qos=1)
+result.wait_for_publish()
+client.loop_stop()
+client.disconnect()
+```
+
+Run it with the connection settings from the previous section:
+
+```bash
+python3 dsx_publish.py
+```
+
+To subscribe from an application, use the same connection setup and register a
+message handler:
+
+```python
+# dsx_subscribe.py
+import os
+
+import paho.mqtt.client as mqtt
+
+
+def on_message(client, userdata, message):
+    print(f"{message.topic}: {message.payload.decode()}")
+
+
+host = os.environ["DSX_MQTT_HOST"]
+port = int(os.getenv("DSX_MQTT_PORT", "1883"))
+topic = os.getenv("DSX_MQTT_TOPIC", "test/hello")
+
+client = mqtt.Client(
+    mqtt.CallbackAPIVersion.VERSION2,
+    client_id=os.getenv("DSX_MQTT_CLIENT_ID", "dsx-quickstart-subscriber"),
+    protocol=mqtt.MQTTv311,
+)
+client.on_message = on_message
+
+username = os.getenv("DSX_MQTT_USERNAME")
+password = os.getenv("DSX_MQTT_PASSWORD")
+if username or password:
+    client.username_pw_set(username, password)
+
+ca_file = os.getenv("DSX_MQTT_CA")
+cert_file = os.getenv("DSX_MQTT_CERT")
+key_file = os.getenv("DSX_MQTT_KEY")
+if ca_file or cert_file or key_file:
+    client.tls_set(ca_certs=ca_file, certfile=cert_file, keyfile=key_file)
+
+client.connect(host, port, keepalive=30)
+client.subscribe(topic, qos=1)
+client.loop_forever()
+```
+
+## CLI Debug Smoke Test
+
+Use a standalone MQTT CLI when you need to isolate broker access, credentials, or
+topic permissions from your application code. Keep one terminal subscribed before
+publishing from another terminal.
 
 ```bash
 mqttx sub \
   -h "${DSX_MQTT_HOST}" \
   -p "${DSX_MQTT_PORT}" \
-  -t "test/hello" \
+  -t "${DSX_MQTT_TOPIC}" \
   -V 3.1.1
 ```
-
-Leave this command running.
-
-## Publish
-
-Open a second terminal with the same `DSX_MQTT_HOST` and `DSX_MQTT_PORT` values, then publish one message:
 
 ```bash
 mqttx pub \
   -h "${DSX_MQTT_HOST}" \
   -p "${DSX_MQTT_PORT}" \
-  -t "test/hello" \
+  -t "${DSX_MQTT_TOPIC}" \
   -m '{"message":"hello from dsx exchange"}' \
   -V 3.1.1
 ```
 
-The subscriber terminal should print the payload:
+The subscriber should print the payload:
 
 ```json
 {"message":"hello from dsx exchange"}
@@ -64,6 +222,10 @@ The subscriber terminal should print the payload:
 
 ## Next Steps
 
+- Build your integration as an application using the MQTT SDK for your runtime.
 - Replace `test/hello` with a topic allowed by your integration's permissions.
 - Use the schema pages to choose the correct topic and payload for your domain.
-- Switch from noauth to the broker's required authentication mode before production use.
+- Use OAuth2 for software integrations or mTLS for BMS, OT, and device
+  integrations before production use. Keep noauth limited to local evaluation
+  and debug environments.
+- Keep standalone MQTT CLIs available for debugging broker connectivity and ACLs.

--- a/docs/integrator-quickstart.md
+++ b/docs/integrator-quickstart.md
@@ -128,9 +128,7 @@ The subscriber should print the payload:
 ## Next Steps
 
 - Build your integration as an application using the MQTT SDK for your runtime.
-- Replace `test/hello` with a topic allowed by your integration's permissions.
-- Use the schema pages to choose the correct topic and payload for your domain.
+- Use the schema pages to choose the correct topics and payloads for your domain.
 - Use OAuth2 for software integrations or mTLS for BMS, OT, and device
   integrations before production use. Keep noauth limited to local evaluation
   and debug environments.
-- Keep standalone MQTT CLIs available for debugging broker connectivity and ACLs.

--- a/docs/integrator-quickstart.md
+++ b/docs/integrator-quickstart.md
@@ -76,16 +76,17 @@ certificate, and client key supplied by the operator.
 
 ## Choose an MQTT SDK
 
-Use the MQTT library that best fits the application you are already building.
-Common options include:
+Use the MQTT library that fits the application you are already building. These
+are examples, not a required list:
 
 | Runtime | SDK examples |
 |---------|--------------|
-| Go | Eclipse Paho Go (`github.com/eclipse/paho.mqtt.golang`) |
-| Python | Eclipse Paho Python (`paho-mqtt`) |
-| Node.js | MQTT.js (`mqtt`) |
-| Java | Eclipse Paho Java |
-| C/C++ | Eclipse Paho C/C++ or libmosquitto |
+| Go | [Eclipse Paho Go](https://eclipse.dev/paho/clients/golang/) |
+| Python | [Eclipse Paho Python](https://eclipse.dev/paho/files/paho.mqtt.python/html/) |
+| Node.js | [MQTT.js](https://github.com/mqttjs/MQTT.js) |
+| Java | [Eclipse Paho Java](https://eclipse.dev/paho/clients/java/) |
+| C | [Eclipse Paho C](https://eclipse.dev/paho/clients/c/) |
+| C++ | [Eclipse Paho C++](https://eclipse.dev/paho/clients/cpp/) |
 
 All SDKs follow the same basic flow:
 
@@ -94,102 +95,6 @@ All SDKs follow the same basic flow:
 3. Connect with the authentication mode assigned by the operator.
 4. Subscribe, publish, or both, using topics allowed by your permissions.
 5. Handle reconnects, publish acknowledgements, and application shutdown.
-
-## Python SDK Sample
-
-This sample uses the Python Paho MQTT SDK to publish one debug message. Replace
-`DSX_MQTT_TOPIC` and the payload with the topic and schema payload for your
-integration.
-
-```bash
-python3 -m pip install paho-mqtt
-```
-
-```python
-# dsx_publish.py
-import json
-import os
-
-import paho.mqtt.client as mqtt
-
-
-host = os.environ["DSX_MQTT_HOST"]
-port = int(os.getenv("DSX_MQTT_PORT", "1883"))
-topic = os.getenv("DSX_MQTT_TOPIC", "test/hello")
-
-client = mqtt.Client(
-    mqtt.CallbackAPIVersion.VERSION2,
-    client_id=os.getenv("DSX_MQTT_CLIENT_ID", "dsx-quickstart-publisher"),
-    protocol=mqtt.MQTTv311,
-)
-
-username = os.getenv("DSX_MQTT_USERNAME")
-password = os.getenv("DSX_MQTT_PASSWORD")
-if username or password:
-    client.username_pw_set(username, password)
-
-ca_file = os.getenv("DSX_MQTT_CA")
-cert_file = os.getenv("DSX_MQTT_CERT")
-key_file = os.getenv("DSX_MQTT_KEY")
-if ca_file or cert_file or key_file:
-    client.tls_set(ca_certs=ca_file, certfile=cert_file, keyfile=key_file)
-
-payload = json.dumps({"message": "hello from dsx exchange"})
-
-client.connect(host, port, keepalive=30)
-client.loop_start()
-result = client.publish(topic, payload, qos=1)
-result.wait_for_publish()
-client.loop_stop()
-client.disconnect()
-```
-
-Run it with the connection settings from the previous section:
-
-```bash
-python3 dsx_publish.py
-```
-
-To subscribe from an application, use the same connection setup and register a
-message handler:
-
-```python
-# dsx_subscribe.py
-import os
-
-import paho.mqtt.client as mqtt
-
-
-def on_message(client, userdata, message):
-    print(f"{message.topic}: {message.payload.decode()}")
-
-
-host = os.environ["DSX_MQTT_HOST"]
-port = int(os.getenv("DSX_MQTT_PORT", "1883"))
-topic = os.getenv("DSX_MQTT_TOPIC", "test/hello")
-
-client = mqtt.Client(
-    mqtt.CallbackAPIVersion.VERSION2,
-    client_id=os.getenv("DSX_MQTT_CLIENT_ID", "dsx-quickstart-subscriber"),
-    protocol=mqtt.MQTTv311,
-)
-client.on_message = on_message
-
-username = os.getenv("DSX_MQTT_USERNAME")
-password = os.getenv("DSX_MQTT_PASSWORD")
-if username or password:
-    client.username_pw_set(username, password)
-
-ca_file = os.getenv("DSX_MQTT_CA")
-cert_file = os.getenv("DSX_MQTT_CERT")
-key_file = os.getenv("DSX_MQTT_KEY")
-if ca_file or cert_file or key_file:
-    client.tls_set(ca_certs=ca_file, certfile=cert_file, keyfile=key_file)
-
-client.connect(host, port, keepalive=30)
-client.subscribe(topic, qos=1)
-client.loop_forever()
-```
 
 ## CLI Debug Smoke Test
 

--- a/docs/integrator-quickstart.md
+++ b/docs/integrator-quickstart.md
@@ -19,19 +19,13 @@ setup, see [Deployment](getting-started.md).
 - Broker host, port, and authentication details from the operator.
 - Topic permissions for the messages your integration will publish or subscribe.
 - An MQTT SDK for the language or platform your application uses.
-- Optional debug tooling such as `mqttx` or `mosquitto-clients`.
+- Optional debug tooling such as `mqttx`.
 - Network access to the broker's MQTT listener.
 
-The local evaluation CSC broker provides a noauth debug path that allows
-publishing and subscribing on `test.>`. This is the NATS subject permission for
-MQTT topic `test/hello`. The broker maps MQTT `/` topic separators to NATS `.`
-subjects.
-
-For production brokers, confirm the configured authentication mode and topic
-permissions with the operator. Most software integrations should use OAuth2.
-BMS, OT, and device integrations commonly use mTLS with client certificates.
-See [Authentication](authentication.md) for OAuth2, mTLS, NKey, and noauth
-configuration.
+For authentication and topic permission configuration, see
+[Authentication](authentication.md). Most software integrations should use
+OAuth2. BMS, OT, and device integrations commonly use mTLS with client
+certificates.
 
 ## Connection Settings
 

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -44,6 +44,9 @@ navigation:
       - page: Deployment
         path: ../docs/getting-started.md
         slug: deployment
+      - page: Integrator Quickstart
+        path: ../docs/integrator-quickstart.md
+        slug: integrator-quickstart
       - page: Operations
         path: ../docs/operations.md
         slug: operations


### PR DESCRIPTION
## Summary
- Adds an integrator quickstart for DSX Exchange docs.
- Wires the page into Fern navigation and discovery links.

## NVBug
6233482

## Validation
- Docs-only branch; verified generated diff and navigation wiring during implementation.
