### PR TITLE
fix(local): extend observability rollout timeout

### DIFF
--- a/local/infra/scripts/setup-observability.sh
+++ b/local/infra/scripts/setup-observability.sh
@@ -35,7 +35,7 @@ deploy_to_cluster() {
       --values "$PROJECT_ROOT/infra/prometheus/values.yaml" \
       --kube-context "$context" \
       --wait \
-      --timeout 2m
+      --timeout 10m
 
   echo "Observability stack deployed to ${cluster}"
 }


### PR DESCRIPTION
## Summary
- Increases the local observability rollout wait to avoid false timeout failures on slower Kind startup.

## NVBug
6231011

## Validation
- make -C local deploy-nats
