### PR TITLE
fix(local): use TLSRoute for mqtt mTLS

### DIFF
--- a/local/infra/envoy-gateway/gateway.yaml
+++ b/local/infra/envoy-gateway/gateway.yaml
@@ -35,11 +35,14 @@ spec:
         namespaces:
           from: All
     - name: mqtt-mtls
-      protocol: TCP
+      protocol: TLS
       port: 8883
+      tls:
+        mode: Passthrough
       allowedRoutes:
         kinds:
-          - kind: TCPRoute
+          - group: gateway.networking.k8s.io
+            kind: TLSRoute
         namespaces:
           from: All
     # Keycloak listener
@@ -66,4 +69,3 @@ spec:
     maxConnections: 32768
     maxPendingRequests: 32768
     maxRequestsPerConnection: 32768
-

--- a/local/nats/k8s/local-dev-values.yaml
+++ b/local/nats/k8s/local-dev-values.yaml
@@ -9,6 +9,10 @@
 # Auth-callout service configuration
 global:
   eventBus:
+    gateway:
+      routes:
+        mqttMtls:
+          kind: TLSRoute
     extraAccounts:
       LaunchLayer:
         enabled: true


### PR DESCRIPTION
## Summary
- Updates the local Envoy Gateway setup to use TLSRoute for MQTT mTLS traffic.
- Adds the local value needed to exercise the mTLS route shape.

## NVBug
6230909

## Validation
- make -C local deploy-nats
