### PR TITLE
fix(deploy): use TLSRoute for mqtt mTLS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ type(scope): short description
 Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
 
 All commits must include a DCO sign-off (`git commit -s`). Semantic-release on main generates tags and changelog from commit types.
+Keep commit message body lines under 100 characters; commitlint enforces this.
 
 ## License headers
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -306,7 +306,7 @@ global:
           sectionName: nats-leafnode
         mqttMtls:
           enabled: true
-          kind: TCPRoute
+          kind: TLSRoute
           gatewayName: shared-gateway
           gatewayNamespace: envoy-gateway-system
           sectionName: mqtt-mtls
@@ -728,14 +728,14 @@ References:
 
 ## Exposed Ports
 
-External access via Envoy Gateway TCPRoutes:
+External access via Envoy Gateway TCPRoutes/TLSRoutes:
 
 | Port | Protocol | Service | Description |
 |------|----------|---------|-------------|
 | 1883 | MQTT | nats | Standard MQTT 3.1.1 (TLS terminated at Envoy) |
 | 4222 | NATS | nats | NATS client connections |
 | 7422 | NATS | nats | Leaf node connections (cross-cluster federation) |
-| 8883 | MQTT | nats-mtls | mTLS MQTT 3.1.1 (TCP passthrough, TLS at NATS pod) |
+| 8883 | MQTT | nats-mtls | mTLS MQTT 3.1.1 (TLS passthrough to NATS pod) |
 
 ### Internal Services
 

--- a/deploy/nats-event-bus/values.yaml
+++ b/deploy/nats-event-bus/values.yaml
@@ -211,7 +211,7 @@ global:
           # hostnames: []  # Optional: only used when kind is TLSRoute
         mqttMtls:
           enabled: true
-          kind: TCPRoute  # TCPRoute or TLSRoute
+          kind: TLSRoute  # TLSRoute preserves the client certificate chain for mTLS
           gatewayName: shared-gateway
           gatewayNamespace: envoy-gateway-system
           sectionName: mqtt-mtls

--- a/local/infra/README.md
+++ b/local/infra/README.md
@@ -116,7 +116,7 @@ Envoy Gateway provides modern, high-performance HTTP/HTTPS ingress and API gatew
 
 **Usage:**
 
-The shared Gateway (`shared-gateway`) is deployed in the `envoy-gateway-system` namespace and provides TCP listeners for NATS (ports 1883, 4222, 7422, 8883) and HTTP listener (port 80) for Keycloak.
+The shared Gateway (`shared-gateway`) is deployed in the `envoy-gateway-system` namespace and provides TCP listeners for NATS (ports 1883, 4222, 7422), a TLS passthrough listener for mTLS MQTT (port 8883), and an HTTP listener (port 80) for Keycloak.
 
 Example HTTPRoute for Keycloak:
 

--- a/local/infra/envoy-gateway/gateway.yaml
+++ b/local/infra/envoy-gateway/gateway.yaml
@@ -35,11 +35,14 @@ spec:
         namespaces:
           from: All
     - name: mqtt-mtls
-      protocol: TCP
+      protocol: TLS
       port: 8883
+      tls:
+        mode: Passthrough
       allowedRoutes:
         kinds:
-          - kind: TCPRoute
+          - group: gateway.networking.k8s.io
+            kind: TLSRoute
         namespaces:
           from: All
     # Keycloak listener
@@ -66,4 +69,3 @@ spec:
     maxConnections: 32768
     maxPendingRequests: 32768
     maxRequestsPerConnection: 32768
-


### PR DESCRIPTION
## Summary
- Defaults the chart MQTT mTLS route to TLSRoute so chart deployments preserve the client certificate chain.
- Configures the local shared Gateway `mqtt-mtls` listener for TLS passthrough and allows TLSRoute.
- Updates route docs where the behavior changed.
- Adds AGENTS.md guidance for commit body line length.

## NVBug
6230899
6230909

## Validation
- `git diff --check`
- `yq '.' local/infra/envoy-gateway/gateway.yaml >/dev/null`
- `make test-helm`
- `make check`
- `make -C local setup-infra`
- `make -C local deploy-nats`
- `make -C local validate-nats`
- `make test-e2e`
