### PR TITLE
fix(chart): normalize MQTT stream sources

### DIFF
--- a/deploy/nats-event-bus/templates/mqtt-streams.yaml
+++ b/deploy/nats-event-bus/templates/mqtt-streams.yaml
@@ -36,6 +36,7 @@ spec:
       subjectTransforms:
         {{- range $crossLayer.cscExports }}
         - source: {{ printf "$MQTT.msgs.%s" . | quote }}
+          dest: "" {{- /* NACK persists omitted destinations this way; keep SSA aligned. */}}
         {{- end }}
         {{- range $crossLayer.cscPrefixedExports }}
         - source: {{ printf "$MQTT.msgs.cpc.%s.%s" $clusterId . | quote }}
@@ -70,6 +71,7 @@ spec:
       subjectTransforms:
         {{- range $crossLayer.cscExports }}
         - source: {{ printf "$MQTT.rmsgs.%s" . | quote }}
+          dest: "" {{- /* NACK persists omitted destinations this way; keep SSA aligned. */}}
         {{- end }}
         {{- range $crossLayer.cscPrefixedExports }}
         - source: {{ printf "$MQTT.rmsgs.cpc.%s.%s" $clusterId . | quote }}

--- a/local/nats/deploy.sh
+++ b/local/nats/deploy.sh
@@ -404,9 +404,8 @@ else
   VALUES_FILES="${VALUES_FILES} -f ${SCRIPT_DIR}/k8s/${cluster}/values.yaml"
 fi
 
-# TODO: Investigate nack jetstream-controller taking ownership of .spec.sources via Update
-# This causes server-side apply conflicts with Helm. Using --force-conflicts as workaround.
-# See: https://github.com/nats-io/nack
+# Keep force-conflicts for source/topology changes where NACK control-loop mode
+# owns existing Stream source fields.
 helm upgrade --install nats-event-bus "${CHART_DIR}" \
   --namespace ${namespace} \
   ${VALUES_FILES} \


### PR DESCRIPTION
## Summary
- Keeps NACK control-loop mode enabled.
- Renders empty CPC source-transform destinations explicitly so Helm SSA matches the Stream spec NACK writes back.
- Keeps the local `--force-conflicts` fallback for actual source/topology changes where NACK owns existing Stream fields.

## NVBug
6230686

## Root cause
NACK normalizes omitted subject transform destinations to `dest: ""`. Helm previously rendered those as absent. After NACK took ownership of `spec.sources`, a no-op Helm upgrade attempted to change the field back to absent and hit an SSA conflict.

## Upstream check
- Current chart dependency: `nack` chart `0.33.2`, app `0.22.2`.
- Latest checked: chart `0.34.0`, app `0.23.0`; no relevant managed-field/source normalization fix found.
- nats-io/nack#99 fixed source updates long before this version; open control-loop issues found are unrelated to this Helm SSA conflict.

## Validation
- `git diff --check origin/main...HEAD`
- `helm lint deploy/nats-event-bus`
- `helm template nats-event-bus deploy/nats-event-bus --namespace event-bus -f local/nats/k8s/local-dev-values.yaml -f local/nats/k8s/cpc/values.yaml -f local/nats/k8s/cpc/cpc-1.yaml --show-only templates/mqtt-streams.yaml`
- `make check`
- Clean e2e setup: `make clean-e2e`, `make -C local setup-infra`, `make -C local deploy-nats`
- `make test-e2e`: functional passed; performance passed with 12 passed, 0 failed
- Post-e2e manual bug check: no-force `helm upgrade` passed on `kind-cpc-1` and `kind-cpc-2`, both revision 2
- Post-e2e stream readiness: all five Stream CRs Ready on both CPC clusters
