### PR TITLE
fix(local): support mac bash for dummy bms

### DIFF
--- a/deploy/scripts/generate-nkeys.sh
+++ b/deploy/scripts/generate-nkeys.sh
@@ -45,6 +45,10 @@ EOF
 cleanup() {
   local dir
 
+  if [ "${#TEMP_DIRS[@]}" -eq 0 ]; then
+    return 0
+  fi
+
   for dir in "${TEMP_DIRS[@]}"; do
     if [ -n "${dir}" ] && [ -d "${dir}" ]; then
       rm -rf "${dir}"
@@ -172,6 +176,10 @@ validate_extra_account_tokens() {
   local account_name
   local token
   local seen_tokens=""
+
+  if [ "${#EXTRA_ACCOUNTS[@]}" -eq 0 ]; then
+    return 0
+  fi
 
   for account_name in "${EXTRA_ACCOUNTS[@]}"; do
     token=$(extra_account_secret_token "${account_name}")
@@ -521,9 +529,11 @@ main() {
     for cpc_id in "${CPC_IDS[@]}"; do
       generate_cluster "cpc-${cpc_id}"
       generate_cpc_leaf_outputs "${cpc_id}"
-      for extra_account in "${EXTRA_ACCOUNTS[@]}"; do
-        generate_extra_account_leaf_outputs "${extra_account}" "${cpc_id}"
-      done
+      if [ "${#EXTRA_ACCOUNTS[@]}" -gt 0 ]; then
+        for extra_account in "${EXTRA_ACCOUNTS[@]}"; do
+          generate_extra_account_leaf_outputs "${extra_account}" "${cpc_id}"
+        done
+      fi
     done
   fi
 

--- a/local/infra/scripts/with-gateway-port-forwards.sh
+++ b/local/infra/scripts/with-gateway-port-forwards.sh
@@ -20,17 +20,21 @@ logs=()
 
 cleanup() {
   local pid
-  for pid in "${pids[@]}"; do
-    if kill -0 "${pid}" >/dev/null 2>&1; then
-      kill "${pid}" >/dev/null 2>&1 || true
-    fi
-  done
-  wait >/dev/null 2>&1 || true
+  if [ "${#pids[@]}" -gt 0 ]; then
+    for pid in "${pids[@]}"; do
+      if kill -0 "${pid}" >/dev/null 2>&1; then
+        kill "${pid}" >/dev/null 2>&1 || true
+      fi
+    done
+    wait >/dev/null 2>&1 || true
+  fi
 
   local log
-  for log in "${logs[@]}"; do
-    rm -f "${log}"
-  done
+  if [ "${#logs[@]}" -gt 0 ]; then
+    for log in "${logs[@]}"; do
+      rm -f "${log}"
+    done
+  fi
 }
 
 trap cleanup EXIT
@@ -48,13 +52,15 @@ gateway_service() {
 wait_for_local_port() {
   local port="$1"
   local log="$2"
+  local pid
 
   for _ in {1..60}; do
     if nc -z 127.0.0.1 "${port}" >/dev/null 2>&1; then
       return 0
     fi
 
-    if ! kill -0 "${pids[-1]}" >/dev/null 2>&1; then
+    pid="${pids[$((${#pids[@]} - 1))]}"
+    if ! kill -0 "${pid}" >/dev/null 2>&1; then
       echo "ERROR: port-forward for local port ${port} exited before becoming ready" >&2
       cat "${log}" >&2
       return 1

--- a/local/mqtt-client/README.md
+++ b/local/mqtt-client/README.md
@@ -179,6 +179,54 @@ your own sample or edit the sample for custom data.
 
 From the repo root, run `make dummy-bms` after the local environment is
 deployed. For direct runs, pass the broker, CSV, and schema paths explicitly.
+Authentication options for real clients are covered in
+[authentication.md](../../docs/authentication.md); the local dummy-BMS target
+uses the no-auth example profile.
+
+### Dummy BMS Scenario CSV
+
+Scenario files must use exactly this header:
+
+```csv
+offset,topic,payload
+```
+
+Each row is one MQTT publish:
+
+- `offset` is a Go duration such as `0s`, `500ms`, or `2m`. Offsets must be
+  non-negative and non-decreasing because they are replayed relative to the
+  start of each pass.
+- `topic` must be a concrete topic that matches a BMS AsyncAPI channel. For
+  BMS-originated sample data, use
+  `BMS/v1/PUB/{Value|Metadata}/{objectType}/{pointType}/{tagPath}`. For
+  example, `BMS/v1/PUB/Metadata/Rack/RackPower/site-a/row-1/rack-1/power` and
+  `BMS/v1/PUB/Value/Rack/RackPower/site-a/row-1/rack-1/power` are valid
+  concrete topics. Empty segments and MQTT wildcards (`+`, `#`) are rejected.
+- `payload` must be JSON and must validate against the BMS AsyncAPI schema for
+  the selected topic. Any topic parameter fields present in the payload must
+  match the topic.
+- `{{timestamp_ms}}` in the payload is replaced at publish time with the current
+  Unix timestamp in milliseconds.
+- `Metadata` topics are published retained. `Value` topics are live,
+  non-retained publishes.
+
+The command loops the scenario until interrupted. Add `--once` to publish one
+pass and exit:
+
+```bash
+go run ./cmd/dummy-bms \
+  --broker tcp://127.0.0.1:11883 \
+  --csv examples/dsx_exemplar.csv \
+  --schema ../../schema/schema/bms/bms.yaml \
+  --once
+```
+
+To verify messages while `make dummy-bms` is running, subscribe to the forwarded
+CSC broker from another terminal:
+
+```bash
+mosquitto_sub -h 127.0.0.1 -p 11883 -t 'BMS/v1/PUB/#' -v
+```
 
 ## Development
 


### PR DESCRIPTION
## Summary
- avoid Bash 3.2 empty-array expansion failures in NKey generation
- replace negative array indexing in the gateway port-forward wrapper used by dummy-BMS
- document the dummy-BMS scenario CSV contract, replay behavior, verification command, and auth reference

## Validation
- git diff --check
- /bin/bash -n deploy/scripts/generate-nkeys.sh
- /bin/bash -n local/infra/scripts/with-gateway-port-forwards.sh
- /bin/bash deploy/scripts/generate-nkeys.sh -o /private/tmp/dsx-nkeys-mac-check 1 2
- go test ./pkg/... ./internal/... ./cmd/... (from local/mqtt-client)
- make -C local check-e2e-env
- /bin/bash infra/scripts/with-gateway-port-forwards.sh sh -c 'cd mqtt-client && go run ./cmd/dummy-bms --broker "$CSC_BROKER_URL" --csv examples/dsx_exemplar.csv --schema ../../schema/schema/bms/bms.yaml --once' (from local/; published 4711/4711 rows)
- make check
- adversarial subagent review: low README topic-shape precision finding addressed