### PR TITLE
docs: make secrets guidance provider-neutral

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -427,7 +427,7 @@ The NATS config uses `<< $VAR >>` placeholders resolved at container runtime. Th
 
 ## Recommended Setup
 
-For production deployment with Vault, cert-manager, and Gateway configuration,
+For production deployment with secrets pipeline, cert-manager, and Gateway configuration,
 see [docs/pre-deployment.md](../docs/pre-deployment.md) and
 [docs/getting-started.md](../docs/getting-started.md).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,8 +136,7 @@ Supported QoS levels:
 
 - **QoS 0** — at most once (fire and forget)
 - **QoS 1** — at least once (acknowledged delivery, backed by JetStream)
-
-QoS 2 (exactly once) is not supported by NATS.
+- **QoS 2** — exactly once (backed by JetStream)
 
 ## Networking
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,7 +54,7 @@ Version-pinned where there is a known compatibility break; see [Pre-Deployment](
 
 ## Secrets
 
-All NKey secrets must be provisioned before deploying the event bus. Use Vault with Vault Secrets Operator to materialize secrets into Kubernetes, or generate locally with the provided script:
+All NKey secrets must be provisioned before deploying the event bus. Any secrets pipeline that materializes Kubernetes Secrets works (see [Pre-Deployment — Secrets Pipeline](pre-deployment.md#secrets-pipeline)). Generate keys locally with the provided script:
 
 ```bash
 # Generate secrets for CSC with CPC IDs 1 and 2

--- a/docs/pre-deployment.md
+++ b/docs/pre-deployment.md
@@ -4,6 +4,19 @@ Everything that must be in place before deploying the DSX Event Bus. This covers
 
 **Estimated time**: The production path (secrets pipeline + certificates) takes 4–6 hours for a first-time deployment across 1 CSC + 2 CPCs. The evaluation path (`local/` Makefile) takes ~10 minutes. See [Deployment — Evaluation Install](getting-started.md) for the quick-start option.
 
+## Host Prerequisites
+
+The 3-cluster Kind topology (CSC + 2 CPCs) creates enough kubelets, containerd shims, gateway controllers, and fsnotify watchers to exhaust default Linux inotify limits. Symptoms include `too many open files` from `kubectl logs -f`, silent fsnotify watcher failures, and sporadic `kubectl exec` errors.
+
+Set these sysctl parameters on the host before creating clusters:
+
+```bash
+sudo sysctl -w fs.inotify.max_user_instances=8192
+sudo sysctl -w fs.inotify.max_user_watches=524288
+```
+
+To persist across reboots, add to `/etc/sysctl.d/` or equivalent for your OS. macOS does not use inotify; see `local/README.md` for macOS-specific setup (MetalLB networking).
+
 ## Infrastructure Prerequisites
 
 The following must be installed in each Kubernetes cluster before deploying the event bus. Components are version-pinned where there is a known API or compatibility break; unpinned components work with any recent release.

--- a/docs/pre-deployment.md
+++ b/docs/pre-deployment.md
@@ -6,16 +6,16 @@ Everything that must be in place before deploying the DSX Event Bus. This covers
 
 ## Host Prerequisites
 
-The 3-cluster Kind topology (CSC + 2 CPCs) creates enough kubelets, containerd shims, gateway controllers, and fsnotify watchers to exhaust default Linux inotify limits. Symptoms include `too many open files` from `kubectl logs -f`, silent fsnotify watcher failures, and sporadic `kubectl exec` errors.
+A multi-cluster deployment (CSC + CPCs) creates enough kubelets, containerd shims, gateway controllers, and fsnotify watchers to exhaust default Linux inotify limits. Symptoms include `too many open files` from `kubectl logs -f`, silent fsnotify watcher failures, and sporadic `kubectl exec` errors.
 
-Set these sysctl parameters on the host before creating clusters:
+Verify these sysctl parameters on each node before creating clusters:
 
 ```bash
 sudo sysctl -w fs.inotify.max_user_instances=8192
 sudo sysctl -w fs.inotify.max_user_watches=524288
 ```
 
-To persist across reboots, add to `/etc/sysctl.d/` or equivalent for your OS. macOS does not use inotify; see `local/README.md` for macOS-specific setup (MetalLB networking).
+To persist across reboots, add to `/etc/sysctl.d/` or equivalent for your OS. For Kind-based local evaluation, see `local/README.md` for additional macOS-specific setup (MetalLB networking).
 
 ## Infrastructure Prerequisites
 
@@ -24,12 +24,12 @@ The following must be installed in each Kubernetes cluster before deploying the 
 | Component | Version | Purpose |
 |-----------|---------|---------|
 | Kubernetes | 1.27+ | Gateway API CRDs require this minimum |
-| Helm | 4.0+ | Chart `apiVersion: v2` features; Helm 3 is not supported |
+| Helm | 3.x or 4.x | Helm 4 required only for `local/` evaluation (uses `--force`); Helm 3 works for production |
 | Gateway API controller | Envoy Gateway 1.5+ | TCPRoute/TLSRoute (`v1alpha2` APIs); older versions lack these CRDs |
 | MetalLB or cloud LB | MetalLB 0.13+ | CRD-based config (`IPAddressPool`, `L2Advertisement`); older versions use incompatible ConfigMap API |
 | cert-manager | — | TLS certificate lifecycle (server certs, mTLS certs) |
 | Prometheus Operator | — | ServiceMonitor CRD (required by Surveyor) |
-| Secrets pipeline | — | Must materialize Kubernetes Secrets (e.g., Vault + Vault Secrets Operator) |
+| Secrets pipeline | — | Must materialize Kubernetes Secrets (e.g., OpenBao/Vault + VSO, sealed-secrets, external-secrets) |
 | [`nsc`](https://github.com/nats-io/nsc/releases) | — | NATS NKey generation (required by `generate-nkeys.sh`) |
 | `nk` | — | NATS NKey inspection (required by `generate-nkeys.sh`) |
 
@@ -126,11 +126,14 @@ A script generates all required secrets for a cluster. Without CPC IDs, only the
 ./deploy/scripts/generate-nkeys.sh [OPTIONS] [cpc-ids...]
 
 # Options:
-#   cpc-ids                  Optional list of CPC IDs to generate with CSC
-#   -o, --output DIR         Output root directory (default: deploy/secrets)
+#   -o, --output DIR             Output root directory (default: deploy/secrets)
+#       --extra-account NAME     Generate CPC-to-CSC leaf keys for an extra account
+#   -h, --help                   Show help message
 
-# Example:
-./deploy/scripts/generate-nkeys.sh 1 2 3    # CSC with CPC IDs 1, 2, 3
+# Examples:
+./deploy/scripts/generate-nkeys.sh                             # CSC only
+./deploy/scripts/generate-nkeys.sh 1 2 3                       # CSC + CPC-1, CPC-2, CPC-3
+./deploy/scripts/generate-nkeys.sh --extra-account LaunchLayer 1 2
 ```
 
 Each key is written as a subdirectory containing `seed` and `pubkey` files:
@@ -166,18 +169,17 @@ secrets/{cluster}/
 
 The event bus consumes Kubernetes Secrets — it does not interact with any secrets backend directly. Any pipeline that materializes the secrets listed in [Required Secrets](#required-secrets) into the target namespace before `helm install` will work. The Helm chart does not assume Vault, sealed-secrets, external-secrets, or any other specific provider.
 
-The project's reference deployment uses HashiCorp Vault with the Vault Secrets Operator (VSO) to materialize secrets and the Vault Agent Injector for auth-callout seed injection. For Vault and VSO installation, configuration, K8s auth methods, policies, and PKI setup, see the HashiCorp documentation:
+One common pattern is [OpenBao](https://openbao.org/) or [HashiCorp Vault](https://developer.hashicorp.com/vault) with the Vault Secrets Operator (VSO) to materialize secrets and the Vault Agent Injector for auth-callout seed injection. For installation, K8s auth methods, policies, and PKI setup, see the respective documentation:
 
+- [OpenBao](https://openbao.org/docs/)
 - [Vault on Kubernetes](https://developer.hashicorp.com/vault/docs/deploy/kubernetes)
 - [Vault Secrets Operator](https://developer.hashicorp.com/vault/docs/deploy/kubernetes/vso)
 - [KV Secret Engine](https://developer.hashicorp.com/vault/docs/secrets/kv)
 - [PKI Secret Engine](https://developer.hashicorp.com/vault/docs/secrets/pki)
 
-[OpenBao](https://openbao.org/) is an open-source fork of Vault with a compatible API and may be used as a drop-in alternative.
-
 ## Certificate Management
 
-cert-manager handles TLS certificate lifecycle. The Issuer can be backed by any supported provider (Vault PKI, self-signed, ACME, etc.). The reference deployment uses a Vault Issuer with PKI engine certificates signed by the event bus Root CA.
+cert-manager handles TLS certificate lifecycle. The Issuer can be backed by any supported provider (Vault/OpenBao PKI, self-signed, ACME, etc.).
 
 ### Server TLS Certificate
 

--- a/docs/pre-deployment.md
+++ b/docs/pre-deployment.md
@@ -1,8 +1,8 @@
 # Pre-Deployment
 
-Everything that must be in place before deploying the DSX Event Bus. This covers infrastructure prerequisites, secrets provisioning, NKey generation, Vault integration, certificate management, and Gateway setup.
+Everything that must be in place before deploying the DSX Event Bus. This covers infrastructure prerequisites, secrets provisioning, NKey generation, certificate management, and Gateway setup.
 
-**Estimated time**: The production path (Vault + VSO + certificates) takes 4–6 hours for a first-time deployment across 1 CSC + 2 CPCs. The evaluation path (`local/` Makefile) takes ~10 minutes. See [Deployment — Evaluation Install](getting-started.md) for the quick-start option.
+**Estimated time**: The production path (secrets pipeline + certificates) takes 4–6 hours for a first-time deployment across 1 CSC + 2 CPCs. The evaluation path (`local/` Makefile) takes ~10 minutes. See [Deployment — Evaluation Install](getting-started.md) for the quick-start option.
 
 ## Infrastructure Prerequisites
 
@@ -149,75 +149,22 @@ secrets/{cluster}/
     xkey.nk
 ```
 
-## Vault Integration (Reference Example)
+## Secrets Pipeline
 
-The interface for secrets is Kubernetes Secrets — any pipeline that materializes them works. The reference deployment uses Vault:
+The event bus consumes Kubernetes Secrets — it does not interact with any secrets backend directly. Any pipeline that materializes the secrets listed in [Required Secrets](#required-secrets) into the target namespace before `helm install` will work. The Helm chart does not assume Vault, sealed-secrets, external-secrets, or any other specific provider.
 
-- **KV Secret Engine** — stores NKeys and seeds
-- **PKI Secret Engine** — Root CA and certificate issuance
-- **Vault Secrets Operator** — materializes Vault KV secrets into Kubernetes secrets
-- **Vault Agent Injector** — injects secrets directly into the auth-callout pod
+The project's reference deployment uses HashiCorp Vault with the Vault Secrets Operator (VSO) to materialize secrets and the Vault Agent Injector for auth-callout seed injection. For Vault and VSO installation, configuration, K8s auth methods, policies, and PKI setup, see the HashiCorp documentation:
 
-```mermaid
-flowchart TB
-    subgraph Vault[Vault]
-        PKI[PKI Engine — Root CA]
-        KV[KV Store — NKeys and Seeds]
-    end
+- [Vault on Kubernetes](https://developer.hashicorp.com/vault/docs/deploy/kubernetes)
+- [Vault Secrets Operator](https://developer.hashicorp.com/vault/docs/deploy/kubernetes/vso)
+- [KV Secret Engine](https://developer.hashicorp.com/vault/docs/secrets/kv)
+- [PKI Secret Engine](https://developer.hashicorp.com/vault/docs/secrets/pki)
 
-    subgraph K8s[Kubernetes Cluster]
-        CM[Cert-Manager]
-        VSO[Vault Secrets Operator]
-        VSS[VaultStaticSecret Resources]
-
-        subgraph Gateway[Gateway API Controller]
-            GW_Listeners[Listeners — MQTT: 1883, 8883 / NATS: 4222, 7422]
-        end
-
-        subgraph EventBus[DSX Event Bus]
-            NATS[NATS Pods — Main + mTLS]
-            AuthCallout[Auth Callout]
-            NACK[NACK Controller]
-        end
-    end
-
-    PKI -->|issues certificates| CM
-    CM -->|server certs| GW_Listeners
-    CM -->|mTLS server certs| NATS
-    CM -->|client certs| AuthCallout
-
-    KV -->|reads secrets| VSO
-    VSO -->|syncs via| VSS
-    VSS -.->|creates K8s secrets| NATS
-    KV -.->|secrets injected| AuthCallout
-    VSS -.->|creates K8s secrets| NACK
-
-    GW_Listeners -->|routes traffic| NATS
-    AuthCallout -->|authenticates| NATS
-    NACK -->|manages streams| NATS
-```
-
-### VaultStaticSecret Example
-
-```yaml
-apiVersion: secrets.hashicorp.com/v1beta1
-kind: VaultStaticSecret
-metadata:
-  name: nack-user
-spec:
-  type: kv-v2
-  vaultAuthRef: vault-secrets-operator-system/vault-auth
-  mount: kv/components
-  path: event-bus/nack-user
-  destination:
-    name: nack-user
-    create: true
-    type: "Opaque"
-```
+[OpenBao](https://openbao.org/) is an open-source fork of Vault with a compatible API and may be used as a drop-in alternative.
 
 ## Certificate Management
 
-cert-manager with a Vault Issuer handles TLS certificate lifecycle. Vault's PKI engine issues certificates signed by the event bus Root CA.
+cert-manager handles TLS certificate lifecycle. The Issuer can be backed by any supported provider (Vault PKI, self-signed, ACME, etc.). The reference deployment uses a Vault Issuer with PKI engine certificates signed by the event bus Root CA.
 
 ### Server TLS Certificate
 

--- a/local/README.md
+++ b/local/README.md
@@ -13,7 +13,7 @@ Version-pinned where there is a known compatibility break; unpinned tools work w
 - Docker Desktop or equivalent
 - [Kind](https://kind.sigs.k8s.io/)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/)
-- [Helm](https://helm.sh/) 4.0+ — Helm 3 is not supported
+- [Helm](https://helm.sh/) 4.0+ — local deploy uses `--force` which requires Helm 4
 - Go 1.25+ — required by `go.mod`
 - Make
 


### PR DESCRIPTION
## Description

Replace Vault-specific installation and integration guidance with provider-neutral "Secrets Pipeline" section. The contract is Kubernetes Secrets; any pipeline that materializes them works. Vault+VSO is mentioned as the project's reference implementation with links to HashiCorp and OpenBao docs, but no inline setup steps.

Addresses NVBugs 6202125, 6202156, 6202170, 6202389, 6202394, 6202405.

Stacked on #33 (README consolidation). Merge #33 first.

Fixes #34

## Validation

```bash
fern check
```

Verified all cross-reference links and anchor targets resolve correctly.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/dsx-exchange/blob/main/CONTRIBUTING.md).
- [x] Documentation updated, if needed.
- [ ] Tests or validation added/updated, if needed.
- [x] License headers are present on applicable source files.
- [ ] Third-party license inventory updated, if dependencies changed.
- [ ] Security-sensitive changes were reviewed privately before public disclosure.
- [x] My commits are signed off (`git commit -s`) per the DCO.