### PR TITLE
docs: document prerequisites and build-from-source requirements

### DIFF
--- a/auth-callout/README.md
+++ b/auth-callout/README.md
@@ -130,6 +130,16 @@ Subject wildcards: `*` matches one token, `>` matches one or more tokens.
 
 See https://docs.nats.io/running-a-nats-service/configuration/securing_nats/authorization for details.
 
+## Building the Container Image
+
+The auth-callout image is not published to a public registry. Build it from source and push to your own registry before deploying:
+
+```bash
+make docker-build        # Produces auth-callout:latest
+```
+
+Set `auth-callout.image.repository` and `auth-callout.image.tag` in your Helm values to point at your registry. See [Pre-Deployment](../docs/pre-deployment.md#auth-callout-container-image) for the full workflow.
+
 ## Development
 
 ### Prerequisites

--- a/auth-callout/deploy/values.yaml
+++ b/auth-callout/deploy/values.yaml
@@ -15,8 +15,12 @@ registry:
   username: ""
   password: ""
 
+# IMPORTANT: This image is NOT published to a public registry.
+# You MUST build it from source (make -C auth-callout docker-build),
+# push to your own registry, and set repository/tag below.
+# See docs/pre-deployment.md for the full workflow.
 image:
-  repository: ghcr.io/nvidia/dsx-exchange/auth-callout
+  repository: registry.example.com/dsx-exchange/auth-callout
   pullPolicy: IfNotPresent
   tag: ""
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,8 +49,9 @@ Version-pinned where there is a known compatibility break; see [Pre-Deployment](
 
 1. Infrastructure (Gateway API controller, MetalLB, cert-manager)
 2. Keycloak or OIDC provider (if using OAuth2)
-3. CSC cluster event bus
-4. CPC cluster event buses (connect to CSC via leaf nodes)
+3. Build the auth-callout container image — see [Pre-Deployment](pre-deployment.md#auth-callout-container-image)
+4. CSC cluster event bus
+5. CPC cluster event buses (connect to CSC via leaf nodes)
 
 ## Secrets
 

--- a/docs/pre-deployment.md
+++ b/docs/pre-deployment.md
@@ -35,6 +35,28 @@ The following must be installed in each Kubernetes cluster before deploying the 
 
 Keycloak or another OIDC provider is required if using OAuth2 authentication.
 
+## Auth-Callout Container Image
+
+The auth-callout container image is not published to a public registry. Operators must build the image from source and push it to their own container registry before deploying the Helm chart.
+
+```bash
+make -C auth-callout docker-build
+# Produces auth-callout:latest
+
+# Tag and push to your registry
+docker tag auth-callout:latest registry.example.com/dsx-exchange/auth-callout:latest
+docker push registry.example.com/dsx-exchange/auth-callout:latest
+```
+
+Then set the image in your Helm values:
+
+```yaml
+auth-callout:
+  image:
+    repository: registry.example.com/dsx-exchange/auth-callout
+    tag: latest
+```
+
 ## Required Secrets
 
 All secrets must be provisioned before `helm install`. Secret names and keys are overridable in Helm values; these are the defaults.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,6 +19,8 @@ The local environment includes MQTT benchmark tooling for smoke runs and
 operator-driven benchmark runs. These tests report the observed behavior of the
 current deployment; they do not define product targets.
 
+**Prerequisite:** Performance and benchmark targets require MetalLB or an equivalent LoadBalancer (installed by `make setup-infra`). Without it, `kubectl port-forward` cannot sustain benchmark throughput and tests fail silently.
+
 The MQTT performance suite exercises combinations of QoS level, retention, and
 deployment topology:
 

--- a/local/README.md
+++ b/local/README.md
@@ -57,20 +57,22 @@ make deploy-nats
 
 ### Run Tests
 
+Performance and benchmark targets require MetalLB (installed by `make setup-infra`). Without it, `kubectl port-forward` is used as a fallback but cannot sustain benchmark throughput — tests fail silently with connectivity errors that do not indicate the root cause.
+
 ```bash
 # Run functional tests against all candidates
 make test-functional
 
-# Run performance e2e smoke tests
+# Run performance e2e smoke tests (requires MetalLB)
 make test-performance
 
-# Run full performance benchmarks
+# Run full performance benchmarks (requires MetalLB)
 make benchmark-performance
 
-# Run MQTT benchmark smoke suite
+# Run MQTT benchmark smoke suite (requires MetalLB)
 make benchmark-basic
 
-# Run full MQTT benchmark suite
+# Run full MQTT benchmark suite (requires MetalLB)
 make benchmark-basic-full
 
 # Publish looping dummy BMS data to the CSC MQTT broker

--- a/local/README.md
+++ b/local/README.md
@@ -14,7 +14,7 @@ Version-pinned where there is a known compatibility break; unpinned tools work w
 - [Kind](https://kind.sigs.k8s.io/)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/)
 - [Helm](https://helm.sh/) 4.0+ — local deploy uses `--force` which requires Helm 4
-- Go 1.25+ — required by `go.mod`
+- [Go](https://go.dev/doc/install) 1.25+ — required by `go.mod`
 - Make
 
 ### MacOS Tweaks


### PR DESCRIPTION
## Description

Document missing prerequisites and build-from-source requirements identified during NVBugs review.

- **auth-callout build** (NVBug 6230606): image is not publicly available — add build instructions to pre-deployment, getting-started install order, and auth-callout README; change chart default to placeholder registry
- **MetalLB for benchmarks** (NVBug 6227016): benchmark targets fail silently without MetalLB — call out the requirement

Fixes #37

## Validation

```bash
# docs-only changes — visual review
```

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/dsx-exchange/blob/main/CONTRIBUTING.md).
- [x] Documentation updated, if needed.
- [ ] Tests or validation added/updated, if needed.
- [ ] License headers are present on applicable source files.
- [ ] Third-party license inventory updated, if dependencies changed.
- [ ] Security-sensitive changes were reviewed privately before public disclosure.
- [x] My commits are signed off (`git commit -s`) per the DCO.