### PR TITLE
docs: document deployment lifecycle gaps

### DIFF
--- a/deploy/nats-event-bus/values.yaml
+++ b/deploy/nats-event-bus/values.yaml
@@ -59,7 +59,9 @@ global:
     # Used to generate leaf node users for cross-cluster connections.
     cpcIds: []  # e.g., ["1", "2"]
 
-    # Cross-layer subject routing configuration
+    # Cross-layer subject routing configuration.
+    # IMPORTANT: The three lists must not overlap. A subject that appears in more
+    # than one list creates cyclic NATS imports that crash the NATS pod.
     crossLayer:
       # Subjects CSC exports to all CPCs (imported unmodified)
       cscExports: []

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,6 +128,8 @@ Cross-layer configuration controls which topics are copied between CPC local and
 
 Routing is enforced by NATS account import/export rules generated from `global.eventBus.crossLayer` Helm values. The Gateway controller does no topic filtering — it passes TCP traffic transparently.
 
+**The three lists must not overlap.** A subject pattern that appears in more than one list creates cyclic NATS imports that crash the NATS pod (CrashLoopBackOff) with no user-facing error at install time.
+
 ## MQTT Support
 
 NATS provides native MQTT 3.1.1 support. MQTT topic separators (`/`) are mapped to NATS subject tokens (`.`) — for example, the MQTT topic `telemetry/temp` becomes the NATS subject `telemetry.temp`. This mapping is transparent to MQTT clients.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -38,7 +38,7 @@ sequenceDiagram
 
 Clients connect with a username of `oauthtoken` and an access token as the password. The auth-callout validates the token against the OIDC provider's JWKS endpoint and matches the token's `azp` (authorized party) or `subject` claim to a permissions entry.
 
-Configure the JWKS endpoint and issuer in the Helm values:
+Configure the JWKS endpoint and issuer in the Helm values for **every cluster** (CSC and each CPC). Without these values, that cluster's auth-callout cannot validate JWTs and silently rejects all OAuth2 connections:
 
 ```yaml
 auth-callout:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -189,7 +189,18 @@ global:
           gatewayName: event-bus-gateway
           gatewayNamespace: event-bus
           sectionName: mqtt-mtls
+          hostnames: ["event-bus.example.com"]
 ```
+
+### mTLS Hostname Agreement
+
+The `mqttMtls` route uses a TLSRoute (Passthrough mode). Three values must agree or clients get a silent connection reset:
+
+1. **Server certificate SANs** — the hostname or IP the cert is issued for
+2. **`mqttMtls.hostnames`** — the SNI values the TLSRoute accepts
+3. **Client broker URL** — MQTT clients derive SNI from the host portion of the URL
+
+If a client connects to `ssl://<LB-IP>:8883`, it sends SNI=`<LB-IP>`. If the TLSRoute hostname is a DNS name, Envoy drops the connection before the TLS handshake reaches the NATS pod. Either add the LB IP to both the cert SANs and the TLSRoute hostnames, or assign a DNS name to the LB IP and have clients use that name.
 
 ## Validation
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -106,7 +106,7 @@ global:
           account: "CSC"
 ```
 
-If using OAuth2, configure the JWKS endpoint and issuer so the auth-callout can validate tokens. Without these, OAuth2 connections are silently rejected:
+If using OAuth2, configure the JWKS endpoint and issuer so the auth-callout can validate tokens. **This must be set on every cluster (CSC and each CPC)**, not just the CSC — without it, that cluster's auth-callout cannot validate JWTs and will silently reject all OAuth2 connections:
 
 ```yaml
 auth-callout:
@@ -141,6 +141,8 @@ global:
       cscPrefixedExports: ["command.>"]
       cpcExports: ["sensor.>"]
 ```
+
+If using OAuth2, each CPC also needs the `auth-callout.serviceConfig.jwks` block — see the CSC section above. Without it, OAuth2 connections to this CPC are silently rejected.
 
 ## Cross-Layer Routing
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -154,6 +154,8 @@ Cross-layer settings control which topics are copied between the CPC local topic
 | CSC to all CPCs | `cscExports` | Broadcast to all CPC topic spaces |
 | CSC to specific CPC | `cscPrefixedExports` | `cpc.{id}.` prefix stripped on delivery |
 
+**The three lists must not overlap.** A subject pattern that appears in more than one list creates cyclic NATS imports that crash the NATS pod (CrashLoopBackOff) with no user-facing error at install time.
+
 ## Gateway Configuration
 
 Configure Gateway API listeners and TCPRoute/TLSRoute resources for external access:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -170,6 +170,49 @@ nack:
       url: "nats://nats:4222"
 ```
 
+## Teardown
+
+`helm uninstall` removes chart-managed resources but leaves operator-provisioned secrets and service accounts in place. This is intentional — the chart does not own those resources.
+
+### Chart uninstall
+
+Run on each cluster (CSC and every CPC):
+
+```bash
+helm uninstall dsx -n dsx
+```
+
+### Removing operator-provisioned resources
+
+If you want a full teardown, delete the secrets and service accounts that were created during pre-deployment. These survive `helm uninstall` because they were created outside the chart:
+
+```bash
+# NKey and TLS secrets
+kubectl -n dsx delete secret \
+  auth-callout-keys event-bus-server-tls-certificate \
+  nats-auth-signing nats-authx-user nats-leaf-csc \
+  nats-nack-user nats-surveyor nats-xkey \
+  --ignore-not-found
+
+# mTLS secrets (if mTLS was enabled)
+kubectl -n dsx delete secret \
+  nats-mtls-server-tls nats-mtls-leaf nats-mtls-authx-leaf nats-mtls-sys-leaf \
+  --ignore-not-found
+
+# Secrets pipeline service accounts (if applicable)
+kubectl -n dsx delete sa event-bus-pki nats-event-bus-vso --ignore-not-found
+```
+
+### Full namespace reset
+
+To remove everything including the namespace:
+
+```bash
+kubectl delete ns dsx --ignore-not-found
+```
+
+If using a Vault-backed secrets pipeline, also remove the Vault PKI role, KV paths, and per-cluster Kubernetes auth mounts for a true clean slate.
+
 ## Chart Dependencies
 
 The `nats-event-bus` umbrella chart bundles these subcharts:

--- a/docs/pre-deployment.md
+++ b/docs/pre-deployment.md
@@ -107,6 +107,17 @@ The generation script always produces mTLS keys (there is no flag to skip them).
 |--------|------|---------|
 | `nats-mtls-server-tls` | ca.crt, tls.crt, tls.key | mTLS server certificates |
 
+The chart does not create a cert-manager Certificate CR for `nats-mtls-server-tls`. Operators must provision this secret before deploying. Use cert-manager with your PKI Issuer, or create the secret manually:
+
+```bash
+kubectl -n dsx create secret generic nats-mtls-server-tls \
+  --from-file=ca.crt=ca.pem \
+  --from-file=tls.crt=server.pem \
+  --from-file=tls.key=server-key.pem
+```
+
+The server certificate SANs must include the hostname or IP that mTLS clients will connect to (see [Deployment — mTLS Hostname Agreement](getting-started.md#mtls-hostname-agreement)).
+
 **Leaf connections:**
 
 | Secret | Keys | Purpose |

--- a/docs/pre-deployment.md
+++ b/docs/pre-deployment.md
@@ -286,6 +286,8 @@ spec:
 
 The `mqtt-mtls` listener uses Passthrough mode because TLS termination happens at the NATS pod to verify the client certificate.
 
+Because the mTLS route is a TLSRoute, the server certificate SANs, the TLSRoute `hostnames`, and the client broker URL must all agree on the same hostname (or IP). A mismatch causes a silent connection reset at the gateway layer. See [Deployment — mTLS Hostname Agreement](getting-started.md#mtls-hostname-agreement).
+
 ### Listener-to-Route Mapping
 
 Gateway listener names must match the `sectionName` in the Helm `gateway.routes` values. Route kind depends on the TLS mode:


### PR DESCRIPTION
## Description

Document deployment and lifecycle gaps identified during NVBugs review.

- **JWKS per-cluster** (NVBug 6230646): clarify that Keycloak/OIDC JWKS config is required on every cluster, not just CSC
- **Cyclic cross-layer overlap** (NVBug 6230631): warn that overlapping import/export subjects cause message loops
- **mTLS SNI/SAN agreement** (NVBug 6230953): document that TLSRoute hostname, certificate SAN, and NATS verify_and_map must align
- **mTLS cert provisioning** (NVBug 6230967): nats-mtls-server-tls must be provisioned manually, not by cert-manager
- **Teardown** (NVBug 6230758): add uninstall/cleanup guidance to operations docs

Fixes #39

## Validation

```bash
# docs-only changes — visual review
```

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/dsx-exchange/blob/main/CONTRIBUTING.md).
- [x] Documentation updated, if needed.
- [ ] Tests or validation added/updated, if needed.
- [ ] License headers are present on applicable source files.
- [ ] Third-party license inventory updated, if dependencies changed.
- [ ] Security-sensitive changes were reviewed privately before public disclosure.
- [x] My commits are signed off (`git commit -s`) per the DCO.