### PR TITLE
docs: add integrator auth modes and MQTT 3.1.1 justification

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,6 +24,10 @@ DSX Exchange consists of four components:
 
 The DSX Event Bus is a [NATS](https://nats.io/)-based messaging platform that provides MQTT 3.1.1 connectivity, [JetStream](https://docs.nats.io/nats-concepts/jetstream) persistence, and multi-cluster [leaf node federation](https://docs.nats.io/running-a-nats-service/configuration/leafnodes) across the AI Factory topology. It is the transport that makes the rest of DSX Exchange possible.
 
+### Why MQTT 3.1.1
+
+DSX Exchange targets MQTT 3.1.1 rather than MQTT 5 because the primary integration surface is building management systems. BMS vendors overwhelmingly ship MQTT 3.1.1 clients, BMS engineers are not typically in a position to adopt newer protocol versions, and the 3.1.1 protocol is simpler with fewer edge cases. This is a deliberate architectural decision — NATS implements MQTT 3.1.1 only, and 3.1.1 maximizes compatibility with the installed base of OT and BMS devices in a gigawatt-scale AI factory.
+
 Concrete signal paths it enables today:
 
 - **BMS -> DPS**: real-time power telemetry so DPS can close the MaxLPS dynamic power allocation loop (recovering up to 40% stranded capacity)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@ The DSX Event Bus is a [NATS](https://nats.io/)-based messaging platform that pr
 
 ### Why MQTT 3.1.1
 
-DSX Exchange targets MQTT 3.1.1 rather than MQTT 5 because the primary integration surface is building management systems. BMS vendors overwhelmingly ship MQTT 3.1.1 clients, BMS engineers are not typically in a position to adopt newer protocol versions, and the 3.1.1 protocol is simpler with fewer edge cases. This is a deliberate architectural decision — NATS implements MQTT 3.1.1 only, and 3.1.1 maximizes compatibility with the installed base of OT and BMS devices in a gigawatt-scale AI factory.
+DSX Exchange targets MQTT 3.1.1 rather than MQTT 5 because a major integration surface is building management systems and industrial OT infrastructure. The BMS and process-control industry overwhelmingly ships MQTT 3.1.1 clients, and the 3.1.1 protocol is simpler with fewer edge cases. This is a deliberate architectural decision — NATS implements MQTT 3.1.1 only, and 3.1.1 maximizes compatibility with the installed base of OT and BMS devices in a gigawatt-scale AI factory.
 
 Concrete signal paths it enables today:
 

--- a/docs/integrator-quickstart.md
+++ b/docs/integrator-quickstart.md
@@ -22,10 +22,24 @@ setup, see [Deployment](getting-started.md).
 - Optional debug tooling such as `mqttx`.
 - Network access to the broker's MQTT listener.
 
-For authentication and topic permission configuration, see
-[Authentication](authentication.md). Most software integrations should use
-OAuth2. BMS, OT, and device integrations commonly use mTLS with client
-certificates.
+## Authentication
+
+DSX Exchange supports three authentication modes. Choose based on your
+environment:
+
+| Mode | When to use | Credentials needed |
+|------|-------------|-------------------|
+| **noauth** | Local evaluation and debugging | None — connect without credentials |
+| **OAuth2** | Software integrations, agents, MCP | MQTT username `oauthtoken`, access token as password |
+| **mTLS** | BMS, OT, and device integrations | CA cert, client cert, client key |
+
+The local evaluation environment deploys with noauth enabled by default, so the
+CLI examples in this guide work without any credentials. For production, the
+operator configures OAuth2, mTLS, or both. Ask your operator which mode and
+credentials to use.
+
+For the full auth model and permission configuration, see
+[Authentication](authentication.md).
 
 ## Connection Settings
 
@@ -52,10 +66,20 @@ export DSX_MQTT_PORT=11883
 export DSX_MQTT_TOPIC=test/hello
 ```
 
-For OAuth2 clients, set the MQTT username to `oauthtoken` and pass the access
-token as the MQTT password.
+### Adding credentials for production
 
-For mTLS clients, configure the SDK's TLS options with the CA certificate, client
+For OAuth2, set the MQTT username to `oauthtoken` and pass the access token as
+the MQTT password. Obtain a token from the OIDC provider configured by your
+operator (e.g., Keycloak):
+
+```bash
+mqttx pub \
+  -h "${DSX_MQTT_HOST}" -p "${DSX_MQTT_PORT}" \
+  -t "${DSX_MQTT_TOPIC}" -m '{"temp":22.5}' \
+  -u oauthtoken -P "${ACCESS_TOKEN}" -V 3.1.1
+```
+
+For mTLS, configure the SDK's TLS options with the CA certificate, client
 certificate, and client key supplied by the operator.
 
 ## Choose an MQTT SDK


### PR DESCRIPTION
## Description

Document integrator-facing architecture gaps identified during NVBugs review.

- **Auth mode guidance** (NVBug 6233507): add auth mode selection section to integrator quickstart covering OAuth2, mTLS, and NKey with when-to-use guidance
- **MQTT 3.1.1 justification** (NVBug 6227020): explain why DSX Exchange targets MQTT 3.1.1 rather than MQTT 5 — BMS vendor compatibility, protocol simplicity, NATS implementation scope

Fixes #41

## Validation

```bash
# docs-only changes — visual review
```

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/dsx-exchange/blob/main/CONTRIBUTING.md).
- [x] Documentation updated, if needed.
- [ ] Tests or validation added/updated, if needed.
- [ ] License headers are present on applicable source files.
- [ ] Third-party license inventory updated, if dependencies changed.
- [ ] Security-sensitive changes were reviewed privately before public disclosure.
- [x] My commits are signed off (`git commit -s`) per the DCO.