### PR TITLE
fix(local): tolerate NATS startup races

### DIFF
--- a/auth-callout/deploy/README.md
+++ b/auth-callout/deploy/README.md
@@ -29,7 +29,7 @@ For mTLS authentication:
 
 | Port | Purpose |
 |------|---------|
-| 8080 | Health checks (`/healthz`) |
+| 8080 | Health checks (`/livez`, `/healthz`) |
 | 9090 | Prometheus metrics (if enabled) |
 
 ## Service Configuration
@@ -277,7 +277,7 @@ healthChecks:
   livenessProbe:
     enabled: true
     httpGet:
-      path: "/healthz"
+      path: "/livez"
       port: "http"
       scheme: "HTTP"
     initialDelaySeconds: 10
@@ -315,7 +315,8 @@ healthChecks:
 
 **Available Health Endpoints:**
 
-- `/healthz` - Primary health check endpoint (recommended)
+- `/livez` - Process liveness check endpoint
+- `/healthz` - Health check endpoint, including NATS connectivity
 - `/v1/` - Basic connectivity test
 
 ## Installation Examples

--- a/auth-callout/deploy/values.yaml
+++ b/auth-callout/deploy/values.yaml
@@ -147,7 +147,7 @@ healthChecks:
   livenessProbe:
     enabled: true # Enable liveness probe
     httpGet:
-      path: "/healthz" # Health check endpoint path
+      path: "/livez" # Liveness endpoint path
       port: "http" # Port name or number
       scheme: "HTTP" # HTTP or HTTPS
     initialDelaySeconds: 10 # Initial delay before starting probes
@@ -160,7 +160,7 @@ healthChecks:
   readinessProbe:
     enabled: true # Enable readiness probe
     httpGet:
-      path: "/healthz" # Health check endpoint path
+      path: "/healthz" # Health endpoint path, including NATS connectivity
       port: "http" # Port name or number
       scheme: "HTTP" # HTTP or HTTPS
     initialDelaySeconds: 5 # Initial delay before starting probes

--- a/auth-callout/docs/basic-profile.md
+++ b/auth-callout/docs/basic-profile.md
@@ -122,9 +122,10 @@ graph TB
 5. **Production Images**: Uses optimized production container images
 
 ### Available Endpoints
-1. **Health Check**: `GET /healthz` - Service health status
-2. **API Ping**: `GET /v1/` - API connectivity test
-3. **API Documentation**: `/swagger/index.html` - Interactive API documentation
+1. **Liveness Check**: `GET /livez` - Process liveness status
+2. **Health Check**: `GET /healthz` - Service health status, including NATS connectivity
+3. **API Ping**: `GET /v1/` - API connectivity test
+4. **API Documentation**: `/swagger/index.html` - Interactive API documentation
 
 ### Development Benefits
 1. **Minimal Overhead**: No observability components consuming resources

--- a/auth-callout/src/cmd/auth_callout/main_test.go
+++ b/auth-callout/src/cmd/auth_callout/main_test.go
@@ -26,7 +26,8 @@ func TestRunServerDoesNotLogConfiguredNATSSeeds(t *testing.T) {
 	t.Setenv("AUTH_CALLOUT_NATS_NKEY_SEED", natsKey)
 	t.Setenv("AUTH_CALLOUT_NATS_ISSUER_SEED", issuerKey)
 	t.Setenv("AUTH_CALLOUT_NATS_XKEY_SEED", xKey)
-	t.Setenv("AUTH_CALLOUT_NATS_URL", "nats://127.0.0.1:1")
+	// Use malformed syntax so startup fails synchronously; valid unavailable URLs now reconnect.
+	t.Setenv("AUTH_CALLOUT_NATS_URL", "nats://%zz")
 	t.Setenv("AUTH_CALLOUT_PERMISSIONS_FILE", permissionsFile)
 	t.Setenv("AUTH_CALLOUT_OBSERVABILITY_METRICS_ENABLED", "false")
 	t.Setenv("AUTH_CALLOUT_OBSERVABILITY_TRACING_ENABLED", "false")

--- a/auth-callout/src/internal/service/health.go
+++ b/auth-callout/src/internal/service/health.go
@@ -7,19 +7,17 @@ import (
 	"net/http"
 )
 
+func livezHandler(w http.ResponseWriter, _ *http.Request) {
+	_, _ = w.Write([]byte("OK"))
+}
+
 // HealthHandler handles health check requests at the "/healthz" endpoint.
-// Returns HTTP 200 OK with "OK" body if the service is healthy.
-func (s *Service) HealthHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Service) HealthHandler(w http.ResponseWriter, _ *http.Request) {
 	// Check NATS connection health
 	if s.natsConn != nil && !s.natsConn.IsConnected() {
 		http.Error(w, "NATS connection lost", http.StatusServiceUnavailable)
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
-	_, err := w.Write([]byte("OK"))
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	_, _ = w.Write([]byte("OK"))
 }

--- a/auth-callout/src/internal/service/service.go
+++ b/auth-callout/src/internal/service/service.go
@@ -31,6 +31,12 @@ import (
 	obstracing "github.com/NVIDIA/dsx-exchange/auth-callout/src/internal/observability/tracing"
 )
 
+const (
+	natsClientName         = "auth-callout-service"
+	natsStartupConnectWait = 2 * time.Second
+	natsMaxReconnects      = -1 // Keep retrying while readiness reports NATS unavailable.
+)
+
 // Service wraps HTTP server with graceful shutdown
 type Service struct {
 	config         ServiceConfig
@@ -191,31 +197,37 @@ func New(config ServiceConfig, logger *otelzap.Logger) *Service {
 // The service will wait for interrupt signals and perform a graceful shutdown with a 5-second timeout.
 func (s *Service) Run() error {
 	// =================================================
-	// Put your unauthenticated routes here (eg healthz)
+	// Put unauthenticated health routes here.
 	// =================================================
+	s.rootRouter.HandleFunc("/livez", livezHandler)
 	s.rootRouter.HandleFunc("/healthz", s.HealthHandler)
 
-	// Connect to NATS
-	var opts []nats.Option
-	if s.config.NATS.NKeySeed != "" {
-		kp, err := nkeys.FromSeed([]byte(s.config.NATS.NKeySeed))
-		if err != nil {
-			return fmt.Errorf("error loading NATS NKey: %w", err)
-		}
-		pubKey, err := kp.PublicKey()
-		if err != nil {
-			return fmt.Errorf("error getting NATS NKey public key: %w", err)
-		}
-		opts = append(opts, nats.Nkey(pubKey, kp.Sign))
+	initialConnectCh := make(chan struct{}, 1)
+	opts, err := s.buildNATSOptions(initialConnectCh)
+	if err != nil {
+		return err
 	}
-	opts = append(opts, nats.Name("auth-callout-service"))
 
 	nc, err := nats.Connect(s.config.NATS.URL, opts...)
 	if err != nil {
 		return fmt.Errorf("error connecting to NATS: %w", err)
 	}
 	s.natsConn = nc
-	s.logger.Info("Connected to NATS", zap.String("url", s.config.NATS.URL))
+	if !nc.IsConnected() {
+		select {
+		case <-initialConnectCh:
+		case <-time.After(natsStartupConnectWait):
+		}
+	}
+	if nc.IsConnected() {
+		s.logger.Info("Connected to NATS", zap.String("url", s.config.NATS.URL))
+	} else {
+		s.logger.Warn(
+			"NATS still connecting after startup check",
+			zap.String("url", s.config.NATS.URL),
+			zap.Duration("timeout", natsStartupConnectWait),
+		)
+	}
 
 	// Create authorization handler
 	authorizerFn := func(req *jwt.AuthorizationRequest) (string, error) {
@@ -292,6 +304,46 @@ func (s *Service) Run() error {
 
 	s.logger.Warn("service shut down successfully")
 	return nil
+}
+
+func (s *Service) buildNATSOptions(initialConnectCh chan<- struct{}) ([]nats.Option, error) {
+	opts := []nats.Option{
+		nats.Name(natsClientName),
+		nats.RetryOnFailedConnect(true),
+		nats.MaxReconnects(natsMaxReconnects),
+		nats.ConnectHandler(func(_ *nats.Conn) {
+			select {
+			case initialConnectCh <- struct{}{}:
+			default:
+			}
+		}),
+		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
+			if err != nil {
+				s.logger.Warn("NATS disconnected", zap.String("url", s.config.NATS.URL), zap.Error(err))
+			}
+		}),
+		nats.ReconnectHandler(func(_ *nats.Conn) {
+			s.logger.Info("Connected to NATS", zap.String("url", s.config.NATS.URL))
+		}),
+		nats.ReconnectErrHandler(func(_ *nats.Conn, err error) {
+			s.logger.Debug("NATS reconnect failed", zap.String("url", s.config.NATS.URL), zap.Error(err))
+		}),
+	}
+
+	if s.config.NATS.NKeySeed == "" {
+		return opts, nil
+	}
+
+	kp, err := nkeys.FromSeed([]byte(s.config.NATS.NKeySeed))
+	if err != nil {
+		return nil, fmt.Errorf("error loading NATS NKey: %w", err)
+	}
+	pubKey, err := kp.PublicKey()
+	if err != nil {
+		return nil, fmt.Errorf("error getting NATS NKey public key: %w", err)
+	}
+
+	return append(opts, nats.Nkey(pubKey, kp.Sign)), nil
 }
 
 // handleAuthRequest processes NATS authorization requests

--- a/auth-callout/src/internal/service/service_test.go
+++ b/auth-callout/src/internal/service/service_test.go
@@ -1,0 +1,180 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/nats-io/jwt/v2"
+	natsserver "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/synadia-io/callout.go"
+	"github.com/uptrace/opentelemetry-go-extra/otelzap"
+	"go.uber.org/zap"
+)
+
+func TestAuthorizationServiceStartsBeforeInitialNATSConnect(t *testing.T) {
+	natsServer := runNATSServer(t)
+	dialer := &gatedDialer{ready: make(chan struct{})}
+	initialConnectCh := make(chan struct{}, 1)
+
+	opts, err := newTestService().buildNATSOptions(initialConnectCh)
+	if err != nil {
+		t.Fatalf("build NATS options: %v", err)
+	}
+	opts = append(opts,
+		nats.SetCustomDialer(dialer),
+		nats.Timeout(50*time.Millisecond),
+		nats.ReconnectWait(50*time.Millisecond),
+	)
+
+	natsConn, err := nats.Connect(natsServer.ClientURL(), opts...)
+	if err != nil {
+		t.Fatalf("connect while NATS dial is blocked: %v", err)
+	}
+	t.Cleanup(natsConn.Close)
+	if natsConn.IsConnected() {
+		t.Fatal("NATS connection is connected, want reconnecting")
+	}
+	authService, err := callout.NewAuthorizationService(
+		natsConn,
+		callout.Name("auth-callout"),
+		callout.Authorizer(func(*jwt.AuthorizationRequest) (string, error) {
+			return "", nil
+		}),
+		callout.ResponseSigner(func(*jwt.AuthorizationResponseClaims) (string, error) {
+			return "", nil
+		}),
+		callout.Logger(noopNATSLogger{}),
+	)
+	if err != nil {
+		t.Fatalf("create authorization service while NATS reconnects: %v", err)
+	}
+	t.Cleanup(func() { _ = authService.Stop() })
+
+	if natsConn.NumSubscriptions() == 0 {
+		t.Fatal("authorization service did not register NATS subscriptions")
+	}
+
+	close(dialer.ready)
+	select {
+	case <-initialConnectCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("NATS connection did not recover after dialer was unblocked")
+	}
+	if !natsConn.IsConnected() {
+		t.Fatal("NATS connection is not connected after initial connect signal")
+	}
+}
+
+func TestLivezHandlerDoesNotRequireNATSConnection(t *testing.T) {
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/livez", nil)
+
+	livezHandler(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusOK)
+	}
+	if body := response.Body.String(); body != "OK" {
+		t.Fatalf("body = %q, want %q", body, "OK")
+	}
+}
+
+func TestHealthHandlerRequiresNATSConnection(t *testing.T) {
+	natsConn := newReconnectingNATSConn(t)
+
+	service := &Service{natsConn: natsConn}
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+
+	service.HealthHandler(response, request)
+
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func newReconnectingNATSConn(t *testing.T) *nats.Conn {
+	t.Helper()
+
+	opts, err := newTestService().buildNATSOptions(make(chan struct{}, 1))
+	if err != nil {
+		t.Fatalf("build NATS options: %v", err)
+	}
+	opts = append(opts,
+		nats.SetCustomDialer(failingDialer{}),
+		nats.Timeout(50*time.Millisecond),
+		nats.ReconnectWait(50*time.Millisecond),
+	)
+
+	natsConn, err := nats.Connect("nats://unavailable.test:4222", opts...)
+	if err != nil {
+		t.Fatalf("connect to unavailable NATS with retry enabled: %v", err)
+	}
+	t.Cleanup(natsConn.Close)
+
+	return natsConn
+}
+
+func runNATSServer(t *testing.T) *natsserver.Server {
+	t.Helper()
+
+	natsServer, err := natsserver.NewServer(&natsserver.Options{
+		Host:   "127.0.0.1",
+		Port:   -1,
+		NoLog:  true,
+		NoSigs: true,
+	})
+	if err != nil {
+		t.Fatalf("create NATS server: %v", err)
+	}
+	natsServer.Start()
+	if !natsServer.ReadyForConnections(2 * time.Second) {
+		natsServer.Shutdown()
+		t.Fatal("NATS server did not become ready")
+	}
+	t.Cleanup(natsServer.Shutdown)
+
+	return natsServer
+}
+
+func newTestService() *Service {
+	return &Service{
+		logger: otelzap.New(zap.NewNop()),
+	}
+}
+
+type failingDialer struct{}
+
+func (failingDialer) Dial(string, string) (net.Conn, error) {
+	return nil, errors.New("dial failed")
+}
+
+type gatedDialer struct {
+	ready chan struct{}
+}
+
+func (d *gatedDialer) Dial(network, address string) (net.Conn, error) {
+	select {
+	case <-d.ready:
+		return (&net.Dialer{}).Dial(network, address)
+	default:
+		return nil, errors.New("dial blocked")
+	}
+}
+
+type noopNATSLogger struct{}
+
+func (noopNATSLogger) Noticef(string, ...any) {}
+func (noopNATSLogger) Warnf(string, ...any)   {}
+func (noopNATSLogger) Fatalf(string, ...any)  {}
+func (noopNATSLogger) Errorf(string, ...any)  {}
+func (noopNATSLogger) Debugf(string, ...any)  {}
+func (noopNATSLogger) Tracef(string, ...any)  {}

--- a/local/nats/deploy.sh
+++ b/local/nats/deploy.sh
@@ -37,6 +37,7 @@ cluster=${1:-csc}
 kind_cluster="${cluster}"
 context="kind-${kind_cluster}"
 namespace="event-bus"
+nats_client_rollout_timeout="10m"
 
 echo "Deploying NATS Event Bus to ${cluster}..."
 
@@ -422,14 +423,14 @@ kubectl delete pods -l app.kubernetes.io/name=auth-callout -n ${namespace} --con
 echo "Waiting for NATS pods to be ready..."
 kubectl rollout status statefulset/nats -n ${namespace} --context "${context}" --timeout=3m
 kubectl rollout status statefulset/nats-mtls -n ${namespace} --context "${context}" --timeout=2m
-kubectl rollout status deployment/nats-event-bus-surveyor -n ${namespace} --context "${context}" --timeout=2m
+kubectl rollout status deployment/nats-event-bus-surveyor -n ${namespace} --context "${context}" --timeout="${nats_client_rollout_timeout}"
 kubectl rollout status deployment/nack -n ${namespace} --context "${context}" --timeout=2m
 
 echo "Waiting for JetStream streams to be ready..."
 kubectl wait --for=condition=Ready stream --all -n ${namespace} --context "${context}" --timeout=2m
 
 echo "Waiting for auth-callout pods to be ready..."
-kubectl rollout status deployment/auth-callout -n ${namespace} --context "${context}" --timeout=2m
+kubectl rollout status deployment/auth-callout -n ${namespace} --context "${context}" --timeout="${nats_client_rollout_timeout}"
 
 echo "Waiting for shared Gateway to be programmed..."
 kubectl wait --for=condition=Programmed gateway/shared-gateway -n envoy-gateway-system --context "${context}" --timeout=2m


### PR DESCRIPTION
## Summary
- keep auth-callout alive when the initial NATS connection is unavailable by enabling initial-connect retry and unlimited reconnects
- split process liveness onto /livez while keeping /healthz NATS-backed for readiness
- extend only local surveyor and auth-callout rollout waits for NATS startup/backoff races

## NVBugs
- 6230705
- 6231022

## Validation
- go test ./src/internal/service
- make test
- make test-helm
- git diff --check
- helm template nats-event-bus deploy/nats-event-bus --show-only charts/auth-callout/templates/deployment.yaml
- make -C local deploy-nats
- make -C local test-functional
- adversarial subagent review: no blocking findings