### PR TITLE
fix(auth-callout): harden oauth jwt validation

### DIFF
--- a/auth-callout/README.md
+++ b/auth-callout/README.md
@@ -35,6 +35,7 @@ nats:
 jwks:
   url: "https://keycloak/realms/master/protocol/openid-connect/certs"
   issuer: "https://keycloak/realms/master"
+  audience: "dsx-exchange"
 
 mtls:
   ca-path: "/etc/ssl/certs/ca.crt"

--- a/auth-callout/api/env.example
+++ b/auth-callout/api/env.example
@@ -8,3 +8,4 @@ NATS_URL=nats://nats:4222
 # JWKS URL for OAuth2 token validation
 JWKS_URL=http://keycloak.127-0-0-1.nip.io:8080/realms/auth-callout/protocol/openid-connect/certs
 JWKS_ISSUER=http://keycloak.127-0-0-1.nip.io:8080/realms/auth-callout
+JWKS_AUDIENCE=dsx-exchange

--- a/auth-callout/deploy/README.md
+++ b/auth-callout/deploy/README.md
@@ -87,6 +87,7 @@ serviceConfig:
   jwks:
     url: "https://keycloak/realms/master/protocol/openid-connect/certs"
     issuer: "https://keycloak/realms/master"
+    audience: "dsx-exchange"
 ```
 
 ### mTLS Configuration

--- a/auth-callout/deploy/values.yaml
+++ b/auth-callout/deploy/values.yaml
@@ -201,6 +201,7 @@ serviceConfig:
   jwks:
     url: ""            # JWKS endpoint URL (e.g., "https://auth.example.com/.well-known/jwks.json")
     issuer: ""         # Expected JWT issuer
+    audience: ""       # Expected JWT audience
 
   # mTLS configuration
   mtls:

--- a/auth-callout/devspace.yaml
+++ b/auth-callout/devspace.yaml
@@ -225,7 +225,20 @@ deployments:
                   "attributes": {
                     "include.in.token.scope": "true",
                     "display.on.consent.screen": "true"
-                  }
+                  },
+                  "protocolMappers": [
+                    {
+                      "name": "dsx-exchange-audience",
+                      "protocol": "openid-connect",
+                      "protocolMapper": "oidc-audience-mapper",
+                      "consentRequired": false,
+                      "config": {
+                        "included.custom.audience": "dsx-exchange",
+                        "id.token.claim": "false",
+                        "access.token.claim": "true"
+                      }
+                    }
+                  ]
                 }
               ],
               "users": []
@@ -371,6 +384,7 @@ deployments:
           jwks:
             url: "http://keycloak-service.keycloak:8080/realms/auth-callout/protocol/openid-connect/certs"
             issuer: "http://keycloak-service.keycloak:8080/realms/auth-callout"
+            audience: "dsx-exchange"
         permissions:
           oauth2:
             csc-admin:

--- a/auth-callout/env.example
+++ b/auth-callout/env.example
@@ -8,6 +8,7 @@ NATS_URL=nats://nats:4222
 # JWKS URL for OAuth2 token validation
 JWKS_URL=http://keycloak.127-0-0-1.nip.io:8080/realms/auth-callout/protocol/openid-connect/certs
 JWKS_ISSUER=http://keycloak.127-0-0-1.nip.io:8080/realms/auth-callout
+JWKS_AUDIENCE=dsx-exchange
 
 # NATS keys are secrets and must come from Vault or generated local files.
 # Generate development values with scripts/devspace-get-key.sh or nsc.

--- a/auth-callout/src/cmd/auth_callout/config/defaults.yaml
+++ b/auth-callout/src/cmd/auth_callout/config/defaults.yaml
@@ -19,6 +19,7 @@ nats:
 jwks:
   url: ""            # JWKS endpoint URL
   issuer: ""         # Expected JWT issuer
+  audience: ""       # Expected JWT audience
 
 # mTLS configuration
 mtls:

--- a/auth-callout/src/internal/appconfig/manager.go
+++ b/auth-callout/src/internal/appconfig/manager.go
@@ -107,6 +107,7 @@ func applyAliases(k *koanf.Koanf) {
 	setString(k, "nats.xkey-seed", "NATS_XKEY_SEED", envPrefix+"NATS_XKEY_SEED")
 	setString(k, "jwks.url", "JWKS_URL", envPrefix+"JWKS_URL")
 	setString(k, "jwks.issuer", "JWKS_ISSUER", envPrefix+"JWKS_ISSUER")
+	setString(k, "jwks.audience", "JWKS_AUDIENCE", envPrefix+"JWKS_AUDIENCE")
 	setString(k, "mtls.ca-path", "MTLS_CA_PATH", envPrefix+"MTLS_CA_PATH")
 	setString(k, "permissions.file", "PERMISSIONS_FILE", envPrefix+"PERMISSIONS_FILE")
 	setString(k, "observability.telemetry.service-name", envPrefix+"SERVICE_NAME")

--- a/auth-callout/src/internal/auth/auth_test.go
+++ b/auth-callout/src/internal/auth/auth_test.go
@@ -83,6 +83,7 @@ func TestOAuth2Authentication(t *testing.T) {
 	oauth2Auth, err := NewOAuth2Authenticator(
 		jwksServer.URL,
 		"https://auth.example.com/",
+		"test-audience",
 		pm,
 		testLogger(),
 		testServiceName,
@@ -179,6 +180,44 @@ func TestOAuth2Authentication(t *testing.T) {
 			expectError:    true,
 			expectedErrMsg: "missing required scope: mqtt",
 		},
+		{
+			name: "missing expiration fails",
+			claims: gojwt.MapClaims{
+				"iss":   "https://auth.example.com/",
+				"sub":   "user@example.com",
+				"aud":   "test-audience",
+				"iat":   now.Unix(),
+				"scope": "mqtt",
+			},
+			expectError:    true,
+			expectedErrMsg: "token is missing required claim: exp claim is required",
+		},
+		{
+			name: "wrong issuer fails",
+			claims: gojwt.MapClaims{
+				"iss":   "https://other.example.com/",
+				"sub":   "user@example.com",
+				"aud":   "test-audience",
+				"exp":   now.Add(1 * time.Hour).Unix(),
+				"iat":   now.Unix(),
+				"scope": "mqtt",
+			},
+			expectError:    true,
+			expectedErrMsg: "token has invalid issuer",
+		},
+		{
+			name: "wrong audience fails",
+			claims: gojwt.MapClaims{
+				"iss":   "https://auth.example.com/",
+				"sub":   "user@example.com",
+				"aud":   "wrong-audience",
+				"exp":   now.Add(1 * time.Hour).Unix(),
+				"iat":   now.Unix(),
+				"scope": "mqtt",
+			},
+			expectError:    true,
+			expectedErrMsg: "token has invalid audience",
+		},
 	}
 
 	for _, tt := range tests {
@@ -205,6 +244,66 @@ func TestOAuth2Authentication(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOAuth2RejectsUnexpectedSigningMethod(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	jwkSet := jwkset.NewMemoryStorage()
+	jwk, err := jwkset.NewJWKFromKey(privateKey, jwkset.JWKOptions{
+		Metadata: jwkset.JWKMetadataOptions{
+			KID: "test-key-1",
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, jwkSet.KeyWrite(context.Background(), jwk))
+
+	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		jwks, err := jwkSet.JSONPublic(context.Background())
+		if err != nil {
+			http.Error(w, "Failed to get JWKS", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write(jwks); err != nil {
+			http.Error(w, "Failed to write JWKS", http.StatusInternalServerError)
+		}
+	}))
+	defer jwksServer.Close()
+
+	permFile := createTestPermissionsFile(t)
+	defer os.Remove(permFile)
+
+	pm, err := config.NewPermissionsManager(permFile, testLogger())
+	require.NoError(t, err)
+	defer pm.Close()
+
+	oauth2Auth, err := NewOAuth2Authenticator(
+		jwksServer.URL,
+		"https://auth.example.com/",
+		"test-audience",
+		pm,
+		testLogger(),
+		testServiceName,
+	)
+	require.NoError(t, err)
+	defer oauth2Auth.Close()
+
+	token := gojwt.NewWithClaims(gojwt.SigningMethodHS256, gojwt.MapClaims{
+		"iss":   "https://auth.example.com/",
+		"sub":   "user@example.com",
+		"aud":   "test-audience",
+		"exp":   time.Now().Add(1 * time.Hour).Unix(),
+		"scope": "mqtt",
+	})
+	token.Header["kid"] = "test-key-1"
+	tokenString, err := token.SignedString([]byte("secret"))
+	require.NoError(t, err)
+
+	_, err = oauth2Auth.Authenticate(context.Background(), tokenString)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "signing method HS256 is invalid")
 }
 
 // TestOAuth2RequiredScope tests per-client required scope validation
@@ -278,6 +377,7 @@ func TestOAuth2RequiredScope(t *testing.T) {
 	oauth2Auth, err := NewOAuth2Authenticator(
 		jwksServer.URL,
 		"https://auth.example.com/",
+		"test-audience",
 		pm,
 		testLogger(),
 		testServiceName,
@@ -299,6 +399,7 @@ func TestOAuth2RequiredScope(t *testing.T) {
 			claims: gojwt.MapClaims{
 				"iss":   "https://auth.example.com/",
 				"sub":   "default@example.com",
+				"aud":   "test-audience",
 				"exp":   now.Add(1 * time.Hour).Unix(),
 				"iat":   now.Unix(),
 				"scope": "mqtt openid",
@@ -311,6 +412,7 @@ func TestOAuth2RequiredScope(t *testing.T) {
 			claims: gojwt.MapClaims{
 				"iss":   "https://auth.example.com/",
 				"sub":   "default@example.com",
+				"aud":   "test-audience",
 				"exp":   now.Add(1 * time.Hour).Unix(),
 				"iat":   now.Unix(),
 				"scope": "openid profile",
@@ -324,6 +426,7 @@ func TestOAuth2RequiredScope(t *testing.T) {
 				"iss":   "https://auth.example.com/",
 				"sub":   "some-service",
 				"azp":   "custom-client-id",
+				"aud":   "test-audience",
 				"exp":   now.Add(1 * time.Hour).Unix(),
 				"iat":   now.Unix(),
 				"scope": "nats:events openid",
@@ -337,6 +440,7 @@ func TestOAuth2RequiredScope(t *testing.T) {
 				"iss":   "https://auth.example.com/",
 				"sub":   "some-service",
 				"azp":   "custom-client-id",
+				"aud":   "test-audience",
 				"exp":   now.Add(1 * time.Hour).Unix(),
 				"iat":   now.Unix(),
 				"scope": "mqtt openid",

--- a/auth-callout/src/internal/auth/oauth2.go
+++ b/auth-callout/src/internal/auth/oauth2.go
@@ -26,6 +26,7 @@ type OAuth2Authenticator struct {
 	jwks        keyfunc.Keyfunc
 	pm          *config.PermissionsManager
 	issuer      string
+	audience    string
 	jwksURL     string
 	logger      *otelzap.Logger
 	serviceName string
@@ -33,7 +34,14 @@ type OAuth2Authenticator struct {
 }
 
 // NewOAuth2Authenticator creates a new OAuth2 authenticator
-func NewOAuth2Authenticator(jwksURL string, issuer string, pm *config.PermissionsManager, logger *otelzap.Logger, serviceName string) (*OAuth2Authenticator, error) {
+func NewOAuth2Authenticator(jwksURL string, issuer string, audience string, pm *config.PermissionsManager, logger *otelzap.Logger, serviceName string) (*OAuth2Authenticator, error) {
+	if issuer == "" {
+		return nil, fmt.Errorf("OAuth2 issuer is required")
+	}
+	if audience == "" {
+		return nil, fmt.Errorf("OAuth2 audience is required")
+	}
+
 	// Create JWKS client with automatic refresh - context controls lifecycle
 	ctx, cancel := context.WithCancel(context.Background())
 	k, err := keyfunc.NewDefaultCtx(ctx, []string{jwksURL})
@@ -48,6 +56,7 @@ func NewOAuth2Authenticator(jwksURL string, issuer string, pm *config.Permission
 		jwks:        k,
 		pm:          pm,
 		issuer:      issuer,
+		audience:    audience,
 		jwksURL:     jwksURL,
 		logger:      logger,
 		serviceName: serviceName,
@@ -78,7 +87,15 @@ func (o *OAuth2Authenticator) Authenticate(ctx context.Context, token string) (*
 	}
 
 	// Parse and validate the JWT token
-	parsed, err := jwt.ParseWithClaims(token, &Claims{}, o.jwks.Keyfunc)
+	parsed, err := jwt.ParseWithClaims(
+		token,
+		&Claims{},
+		o.jwks.Keyfunc,
+		jwt.WithValidMethods([]string{jwt.SigningMethodRS256.Alg()}),
+		jwt.WithExpirationRequired(),
+		jwt.WithIssuer(o.issuer),
+		jwt.WithAudience(o.audience),
+	)
 	if err != nil {
 		if counter, err := meter.Int64Counter("auth_oauth2_failures_total",
 			metric.WithDescription("Total OAuth2 authentication failures")); err == nil {
@@ -111,18 +128,6 @@ func (o *OAuth2Authenticator) Authenticate(ctx context.Context, token string) (*
 			))
 		}
 		return nil, fmt.Errorf("invalid claims type")
-	}
-
-	// Validate issuer if configured
-	if o.issuer != "" && claims.Issuer != o.issuer {
-		if counter, err := meter.Int64Counter("auth_oauth2_failures_total",
-			metric.WithDescription("Total OAuth2 authentication failures")); err == nil {
-			counter.Add(ctx, 1, metric.WithAttributes(
-				attribute.String("method", "oauth2"),
-				attribute.String("reason", "invalid_issuer"),
-			))
-		}
-		return nil, fmt.Errorf("invalid issuer: expected %s, got %s", o.issuer, claims.Issuer)
 	}
 
 	// Look up user profile in permissions config using both subject and azp

--- a/auth-callout/src/internal/service/service.go
+++ b/auth-callout/src/internal/service/service.go
@@ -77,8 +77,9 @@ type NATSConfig struct {
 
 // JWKSConfig contains OAuth2/JWKS configuration
 type JWKSConfig struct {
-	URL    string `koanf:"url"`
-	Issuer string `koanf:"issuer"`
+	URL      string `koanf:"url"`
+	Issuer   string `koanf:"issuer"`
+	Audience string `koanf:"audience"`
 }
 
 // MTLSConfig contains mTLS configuration
@@ -133,7 +134,7 @@ func New(config ServiceConfig, logger *otelzap.Logger) *Service {
 
 	// OAuth2 authenticator
 	if config.JWKS.URL != "" {
-		oauth2Auth, err := auth.NewOAuth2Authenticator(config.JWKS.URL, config.JWKS.Issuer, pm, logger, serviceName)
+		oauth2Auth, err := auth.NewOAuth2Authenticator(config.JWKS.URL, config.JWKS.Issuer, config.JWKS.Audience, pm, logger, serviceName)
 		if err != nil {
 			logger.Fatal("error initializing OAuth2 authenticator", zap.Error(err))
 		}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -405,6 +405,7 @@ auth-callout:
     jwks:
       url: "https://keycloak.example.com/realms/event-bus/protocol/openid-connect/certs"
       issuer: "https://keycloak.example.com/realms/event-bus"
+      audience: "dsx-exchange"
 ```
 
 Auth permissions are configured via `global.eventBus.auth.permissions`, not under `auth-callout`. See [auth-callout Helm chart documentation](../auth-callout/deploy/README.md).
@@ -543,6 +544,7 @@ auth-callout:
     jwks:
       url: "https://keycloak.example.com/realms/event-bus/protocol/openid-connect/certs"
       issuer: "https://keycloak.example.com/realms/event-bus"
+      audience: "dsx-exchange"
     mtls:
       ca-path: "/etc/mtls-ca/ca.crt"
 ```

--- a/local/infra/keycloak/realm-csc.json
+++ b/local/infra/keycloak/realm-csc.json
@@ -87,7 +87,20 @@
       "attributes": {
         "include.in.token.scope": "true",
         "display.on.consent.screen": "true"
-      }
+      },
+      "protocolMappers": [
+        {
+          "name": "dsx-exchange-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "dsx-exchange",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ]
     }
   ],
   "users": []

--- a/local/nats/k8s/local-dev-values.yaml
+++ b/local/nats/k8s/local-dev-values.yaml
@@ -26,6 +26,7 @@ auth-callout:
     jwks:
       url: "http://172.18.200.1/realms/event-bus/protocol/openid-connect/certs"
       issuer: "http://172.18.200.1/realms/event-bus"
+      audience: "dsx-exchange"
     # CA certificate for mTLS client verification
     mtls:
       ca-path: "/etc/mtls-ca/ca.crt"


### PR DESCRIPTION
## Summary
- Require configured OAuth2 issuer and audience when JWKS auth is enabled.
- Validate OAuth2 tokens with RS256, required exp, issuer, and audience parser checks.
- Update local Keycloak/dev values so local OAuth2 tokens include the expected dsx-exchange audience.

## Validation
- go test -count=1 ./src/internal/auth ./src/internal/service ./src/internal/appconfig ./src/cmd/auth_callout
- helm lint auth-callout/deploy
- helm template test-release auth-callout/deploy >/dev/null
- helm template csc deploy/nats-event-bus -f local/nats/k8s/local-dev-values.yaml -f local/nats/k8s/csc/values.yaml >/dev/null