### PR TITLE
fix(auth-callout): remove configmap seed config

### DIFF
--- a/auth-callout/README.md
+++ b/auth-callout/README.md
@@ -28,9 +28,6 @@ host:
 
 nats:
   url: "nats://nats:4222"
-  nkey-seed: "SUAM..."      # connection NKey seed (from Vault)
-  issuer-seed: "SAAG..."    # account signing key seed (from Vault)
-  xkey-seed: "SXAE..."      # encryption XKey seed (optional, from Vault)
 
 jwks:
   url: "https://keycloak/realms/master/protocol/openid-connect/certs"
@@ -57,15 +54,18 @@ observability:
 
 ### NKey Seeds
 
-The service requires three NKey seeds for NATS authentication:
+The service requires NATS seed material from environment variables or a secret-backed config file:
 
-| Key | Seed Prefix | Public Key Prefix | Purpose |
-|-----|-------------|-------------------|---------|
-| `nkey-seed` | `SU` | `U` | Auth callout connects to NATS |
-| `issuer-seed` | `SA` | `A` | Signs user JWTs for authenticated clients |
-| `xkey-seed` | `SX` | `X` | Encrypts responses (optional) |
+| Environment variable | Seed Prefix | Public Key Prefix | Purpose |
+|----------------------|-------------|-------------------|---------|
+| `AUTH_CALLOUT_NATS_NKEY_SEED` | `SU` | `U` | Auth callout connects to NATS |
+| `AUTH_CALLOUT_NATS_ISSUER_SEED` | `SA` | `A` | Signs user JWTs for authenticated clients |
+| `AUTH_CALLOUT_NATS_XKEY_SEED` | `SX` | `X` | Encrypts responses (optional) |
 
-Seeds are secrets (store in Vault). Public keys are configured in NATS server.
+Secret files use the same config keys: `nats.nkey-seed`, `nats.issuer-seed`,
+and `nats.xkey-seed`.
+
+Seeds are secrets. Public keys are configured in NATS server.
 See [docs/pre-deployment.md](../docs/pre-deployment.md) for the full key
 inventory and generation script.
 

--- a/auth-callout/deploy/README.md
+++ b/auth-callout/deploy/README.md
@@ -42,15 +42,11 @@ The auth callout connects to a NATS server and registers as an authorization ser
 serviceConfig:
   nats:
     url: "nats://nats:4222"    # NATS server URL
-    nkey-seed: ""              # NKey seed; inject non-empty values as env or Vault secrets
-    issuer-seed: ""            # Account issuer seed; inject non-empty values as env or Vault secrets
-    xkey-seed: ""              # XKey seed; inject non-empty values as env or Vault secrets
 ```
 
-The chart renders these keys with empty defaults. Do not put real seed material
-directly in `serviceConfig`, which renders into a ConfigMap. Inject non-empty
-values with environment variables or Vault hot config. See
-[Vault Integration](#vault-integration).
+NATS credentials are supplied with environment variables or a mounted secret
+file. For a secret file, mount the Secret and set `AUTH_CALLOUT_HOT_CONFIG` to
+the mounted path.
 
 ### Environment Injection
 

--- a/auth-callout/deploy/values.yaml
+++ b/auth-callout/deploy/values.yaml
@@ -193,9 +193,6 @@ serviceConfig:
   # NATS connection configuration
   nats:
     url: "nats://nats:4222"
-    nkey-seed: ""
-    issuer-seed: ""
-    xkey-seed: ""
 
   # OAuth2/JWKS configuration (non-secrets)
   jwks:

--- a/auth-callout/devspace.yaml
+++ b/auth-callout/devspace.yaml
@@ -378,13 +378,17 @@ deployments:
         serviceConfig:
           nats:
             url: "nats://nats:4222"
-            nkey-seed: ${AUTH_USER_NKEY_SEED}
-            issuer-seed: ${AUTH_SIGNING_KEY_SEED}
-            xkey-seed: ${XKEY_SEED}
           jwks:
             url: "http://keycloak-service.keycloak:8080/realms/auth-callout/protocol/openid-connect/certs"
             issuer: "http://keycloak-service.keycloak:8080/realms/auth-callout"
             audience: "dsx-exchange"
+        extraEnvs:
+          AUTH_CALLOUT_NATS_NKEY_SEED:
+            value: ${AUTH_USER_NKEY_SEED}
+          AUTH_CALLOUT_NATS_ISSUER_SEED:
+            value: ${AUTH_SIGNING_KEY_SEED}
+          AUTH_CALLOUT_NATS_XKEY_SEED:
+            value: ${XKEY_SEED}
         permissions:
           oauth2:
             csc-admin:

--- a/auth-callout/src/cmd/auth_callout/config/defaults.yaml
+++ b/auth-callout/src/cmd/auth_callout/config/defaults.yaml
@@ -10,10 +10,6 @@ host:
 # NATS connection and auth callout configuration
 nats:
   url: "nats://localhost:4222"
-  # Seeds are secrets - provided via Vault, not here
-  nkey-seed: ""      # NATS connection NKey seed (from Vault)
-  issuer-seed: ""    # Issuer account signing key seed (from Vault)
-  xkey-seed: ""      # XKey seed for encryption (from Vault, optional)
 
 # OAuth2/JWKS configuration (non-secrets)
 jwks:

--- a/auth-callout/src/internal/appconfig/manager_test.go
+++ b/auth-callout/src/internal/appconfig/manager_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package appconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadAllowsNATSSeedsInHotConfigAndEnvironment(t *testing.T) {
+	hotConfigPath := writeConfigFile(t, "config-secrets.yaml", `
+nats:
+  nkey-seed: SUFAKE
+  issuer-seed: SAFAKE
+  xkey-seed: SXFAKE
+`)
+	t.Setenv("AUTH_CALLOUT_HOT_CONFIG", hotConfigPath)
+	t.Setenv("AUTH_CALLOUT_NATS_ISSUER_SEED", "SAFROMENV")
+
+	manager := New("")
+	require.NoError(t, manager.Load())
+
+	type natsConfig struct {
+		NATS struct {
+			NKeySeed   string `koanf:"nkey-seed"`
+			IssuerSeed string `koanf:"issuer-seed"`
+			XKeySeed   string `koanf:"xkey-seed"`
+		} `koanf:"nats"`
+	}
+	var config natsConfig
+	require.NoError(t, manager.Unmarshal(&config))
+	require.Equal(t, "SUFAKE", config.NATS.NKeySeed)
+	require.Equal(t, "SAFROMENV", config.NATS.IssuerSeed)
+	require.Equal(t, "SXFAKE", config.NATS.XKeySeed)
+}
+
+func writeConfigFile(t *testing.T, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}


### PR DESCRIPTION
## Summary
- Remove NATS seed fields from auth-callout serviceConfig defaults and docs.
- Document NATS seed material through AUTH_CALLOUT_NATS_* environment variables or a mounted secret config file.
- Move standalone devspace seed injection from serviceConfig to env vars.

## Validation
- go test -count=1 ./... from auth-callout/
- helm lint auth-callout/deploy
- helm template test-release auth-callout/deploy
- helm template devspace auth-callout/deploy with AUTH_CALLOUT_NATS_* extraEnvs renders successfully
- helm dependency build deploy/nats-event-bus
- helm lint deploy/nats-event-bus
- helm template csc deploy/nats-event-bus -f local/nats/k8s/local-dev-values.yaml -f local/nats/k8s/csc/values.yaml --show-only charts/auth-callout/templates/configmap.yaml