### PR TITLE
fix(docs): point values example to local setup

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -217,9 +217,15 @@ helm install dsx ./nats-event-bus -n dsx --create-namespace --dry-run
 # Install
 helm install dsx ./nats-event-bus -n dsx --create-namespace
 
-# With custom values
-helm install dsx ./nats-event-bus -n dsx --create-namespace -f values-csc.yaml
+# Run the local setup from the repository root
+make -C local setup-infra
+make -C local deploy-nats
 ```
+
+The local setup deploys the same chart with values from `local/nats/k8s/`.
+Use `local/nats/k8s/local-dev-values.yaml`, `local/nats/k8s/csc/values.yaml`,
+`local/nats/k8s/cpc/values.yaml`, and the per-CPC files in
+`local/nats/k8s/cpc/` as the working reference for value layering.
 
 ## Umbrella Chart Configuration
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,6 +16,13 @@ make -C local validate-nats     # Verify connectivity
 
 See `local/README.md` for the full set of evaluation targets including functional tests, performance benchmarks, and MQTT client tooling.
 
+Use the local setup as the runnable end-to-end example. Its Helm values live in
+`local/nats/k8s/`: shared local settings in `local-dev-values.yaml`, CSC settings
+in `csc/values.yaml`, shared CPC settings in `cpc/values.yaml`, and per-cluster
+CPC overrides in `cpc/cpc-1.yaml` and `cpc/cpc-2.yaml`. Use these files as the
+concrete reference for value layering. Do not copy them to production unchanged
+because they use local images, local Keycloak, and Kind networking.
+
 If you already have access to a running broker and need to build or test an MQTT
 integration application, use the [Integrator Quickstart](integrator-quickstart.md)
 instead of this operator deployment flow.
@@ -76,9 +83,12 @@ helm dependency update ./deploy/nats-event-bus
 
 helm install dsx ./deploy/nats-event-bus \
   -n dsx --create-namespace \
-  -f values-common.yaml \
-  -f values-csc.yaml
+  -f <your-csc-values.yaml>
 ```
+
+For a working CSC reference, see `local/nats/k8s/local-dev-values.yaml` and
+`local/nats/k8s/csc/values.yaml`. Those are the values applied by
+`make -C local deploy-nats`.
 
 CSC values configure the cluster type, list of CPC IDs that will connect, and auth permissions:
 
@@ -123,10 +133,13 @@ The CSC also needs CPC leaf user public keys to authorize incoming leaf connecti
 ```bash
 helm install dsx ./deploy/nats-event-bus \
   -n dsx --create-namespace \
-  -f values-common.yaml \
-  -f values-cpc.yaml \
-  -f values-cpc-1.yaml    # cluster-specific overrides
+  -f <your-cpc-common-values.yaml> \
+  -f <your-cpc-1-values.yaml>
 ```
+
+For a working CPC reference, see `local/nats/k8s/local-dev-values.yaml`,
+`local/nats/k8s/cpc/values.yaml`, and `local/nats/k8s/cpc/cpc-1.yaml`. Those are
+the values applied by `make -C local deploy-nats`.
 
 CPC values set the cluster type, cluster ID, CSC endpoint, and cross-layer routing:
 


### PR DESCRIPTION
## Summary
- Point deployment docs at the local setup as the runnable end-to-end example.
- Replace nonexistent standalone values-file references with production values placeholders.
- Reference the concrete local Helm values under `local/nats/k8s/`.

## NVBug
- 6202409

## Root Cause
The docs pointed readers at standalone values files or a separate template path
that did not ship with the repo. The local setup already deploys a fully working
CSC plus CPC example and owns the concrete Helm values used for that path.

## Validation
- Reviewed NVBug 6202409 with the NVBugs V2 MCP read-only tools.
- `tools/check-docs-mdx docs/getting-started.md deploy/README.md`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Event Bus deployment with updated Helm install snippets for CSC and CPC clusters.
  * Introduced a maintained local example workflow—includes commands to set up local infra and deploy the messaging component.
  * Explained how layered Helm values are used in the local example and warned against copying those local values directly to production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->