### PR TITLE
fix(power-management-schema): move event to feeds

### DIFF
--- a/docs/schema-power-management-schemas.mdx
+++ b/docs/schema-power-management-schemas.mdx
@@ -148,6 +148,7 @@ Current power state for a single feed.
 | `calculated_load.value` | number (double) | Yes | Power value (must be >= 0). |
 | `calculated_load.unit` | string | Yes | Unit of measurement. Values: `watt`, `kilowatt`, `megawatt` |
 | `in_flight` | boolean | Yes | true if the agent is actively transitioning between power levels. |
+| `event` | string | Yes | The trigger that caused this status to be published: - target_set — a grid.loadtarget.set.v1 was received and schedule updated - start_ramp_down — constraint applied or tightened, redistribution be... |
 | `power_event_start_time` | string (date-time) | No | ISO 8601 UTC timestamp when the current power event began. null if no event is active. |
 | `compliant` | boolean | Yes | true if the calculated load is within the active target constraint. true when no target is active. |
 
@@ -195,7 +196,6 @@ Payload for grid.powerstate.status.v1.
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | `snapshot_time` | string (date-time) | Yes | ISO 8601 UTC timestamp of this snapshot. |
-| `event` | string | Yes | The trigger that caused this status to be published: - target_set — a grid.loadtarget.set.v1 was received and schedule updated - start_ramp_down — constraint applied or tightened, redistribution be... |
 | `feeds` | map\&lt;string, [FeedState](schema-power-management-schemas.mdx#feedstate)\> | Yes | Map of feed_tag to power state. |
 
 ---

--- a/docs/schema-power-management.mdx
+++ b/docs/schema-power-management.mdx
@@ -489,7 +489,7 @@ components:
     FeedState:
       type: object
       description: Current power state for a single feed.
-      required: [metadata, targets, calculated_load, in_flight, compliant]
+      required: [metadata, targets, calculated_load, in_flight, event, compliant]
       properties:
         metadata:
           $ref: '#/components/schemas/FeedMetadata'
@@ -507,6 +507,23 @@ components:
         in_flight:
           type: boolean
           description: true if the agent is actively transitioning between power levels.
+        event:
+          type: string
+          enum:
+            - target_set
+            - start_ramp_down
+            - end_ramp_down
+            - start_ramp_up
+            - end_ramp_up
+            - periodic
+          description: |
+            The trigger that caused this status to be published:
+            - target_set — a grid.loadtarget.set.v1 was received and schedule updated
+            - start_ramp_down — constraint applied or tightened, redistribution begins
+            - end_ramp_down — redistribution complete, load converged to target
+            - start_ramp_up — constraint relaxed or removed, redistribution begins
+            - end_ramp_up — redistribution complete
+            - periodic — regular heartbeat, no state change
         power_event_start_time:
           type: string
           format: date-time
@@ -585,29 +602,12 @@ components:
     PowerStateStatusData:
       type: object
       description: Payload for grid.powerstate.status.v1.
-      required: [snapshot_time, event, feeds]
+      required: [snapshot_time, feeds]
       properties:
         snapshot_time:
           type: string
           format: date-time
           description: ISO 8601 UTC timestamp of this snapshot.
-        event:
-          type: string
-          enum:
-            - target_set
-            - start_ramp_down
-            - end_ramp_down
-            - start_ramp_up
-            - end_ramp_up
-            - periodic
-          description: |
-            The trigger that caused this status to be published:
-            - target_set — a grid.loadtarget.set.v1 was received and schedule updated
-            - start_ramp_down — constraint applied or tightened, redistribution begins
-            - end_ramp_down — redistribution complete, load converged to target
-            - start_ramp_up — constraint relaxed or removed, redistribution begins
-            - end_ramp_up — redistribution complete
-            - periodic — regular heartbeat, no state change
         feeds:
           type: object
           description: Map of feed_tag to power state.

--- a/schemas/asyncapi/power-management/power-management.yaml
+++ b/schemas/asyncapi/power-management/power-management.yaml
@@ -400,7 +400,7 @@ components:
     FeedState:
       type: object
       description: Current power state for a single feed.
-      required: [metadata, targets, calculated_load, in_flight, compliant]
+      required: [metadata, targets, calculated_load, in_flight, event, compliant]
       properties:
         metadata:
           $ref: '#/components/schemas/FeedMetadata'
@@ -513,7 +513,7 @@ components:
     PowerStateStatusData:
       type: object
       description: Payload for grid.powerstate.status.v1.
-      required: [snapshot_time, event, feeds]
+      required: [snapshot_time, feeds]
       properties:
         snapshot_time:
           type: string

--- a/schemas/asyncapi/power-management/power-management.yaml
+++ b/schemas/asyncapi/power-management/power-management.yaml
@@ -418,6 +418,23 @@ components:
         in_flight:
           type: boolean
           description: true if the agent is actively transitioning between power levels.
+        event:
+          type: string
+          enum:
+            - target_set
+            - start_ramp_down
+            - end_ramp_down
+            - start_ramp_up
+            - end_ramp_up
+            - periodic
+          description: |
+            The trigger that caused this status to be published:
+            - target_set — a grid.loadtarget.set.v1 was received and schedule updated
+            - start_ramp_down — constraint applied or tightened, redistribution begins
+            - end_ramp_down — redistribution complete, load converged to target
+            - start_ramp_up — constraint relaxed or removed, redistribution begins
+            - end_ramp_up — redistribution complete
+            - periodic — regular heartbeat, no state change
         power_event_start_time:
           type: string
           format: date-time
@@ -502,23 +519,6 @@ components:
           type: string
           format: date-time
           description: ISO 8601 UTC timestamp of this snapshot.
-        event:
-          type: string
-          enum:
-            - target_set
-            - start_ramp_down
-            - end_ramp_down
-            - start_ramp_up
-            - end_ramp_up
-            - periodic
-          description: |
-            The trigger that caused this status to be published:
-            - target_set — a grid.loadtarget.set.v1 was received and schedule updated
-            - start_ramp_down — constraint applied or tightened, redistribution begins
-            - end_ramp_down — redistribution complete, load converged to target
-            - start_ramp_up — constraint relaxed or removed, redistribution begins
-            - end_ramp_up — redistribution complete
-            - periodic — regular heartbeat, no state change
         feeds:
           type: object
           description: Map of feed_tag to power state.


### PR DESCRIPTION
## Description

Moved the `PowerStateStatusData.event` field under the FeedState because each power feed may be in transition due to a different event.

## Checklist

- [X ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/dsx-exchange/blob/main/CONTRIBUTING.md).
- [ ] Documentation updated, if needed.
- [ ] Tests or validation added/updated, if needed.
- [X ] License headers are present on applicable source files.
- [ ] Third-party license inventory updated, if dependencies changed.
- [ ] Security-sensitive changes were reviewed privately before public disclosure.
- [ X] My commits are signed off (`git commit -s`) per the DCO.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Each feed now includes a required "event" label describing why that feed's power-state snapshot was published (target_set, start_ramp_down, end_ramp_down, start_ramp_up, end_ramp_up, periodic).

* **Bug Fixes**
  * Removed the top-level "event" from the overall power-status payload to ensure consistent validation and a clearer per-feed event model.

* **Documentation**
  * Schema docs updated to reflect the per-feed event field and removal of the top-level event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->