### PR TITLE
fix(security): remediate audit findings

### DIFF
--- a/auth-callout/deploy/values.yaml
+++ b/auth-callout/deploy/values.yaml
@@ -214,8 +214,8 @@ serviceConfig:
   # Observability configuration
   observability:
     logging:
-      level: debug
-      zap-configuration: development
+      level: info
+      zap-configuration: production
     telemetry:
       deployment-environment-name: local
       service-name: auth-callout

--- a/auth-callout/src/internal/auth/auth_test.go
+++ b/auth-callout/src/internal/auth/auth_test.go
@@ -565,6 +565,49 @@ func TestNKeyAuthentication(t *testing.T) {
 	t.Logf("NKey authentication successful for key: %s", publicKey)
 }
 
+func TestNKeyTryAuthenticateDoesNotEchoMalformedPublicKey(t *testing.T) {
+	permFile := createTestPermissionsFile(t)
+	defer os.Remove(permFile)
+
+	pm, err := config.NewPermissionsManager(permFile, testLogger())
+	require.NoError(t, err)
+	defer pm.Close()
+
+	authenticator := NewNKeyAuthenticator(pm, testLogger(), testServiceName)
+	rc := &jwt.AuthorizationRequestClaims{}
+	rc.ConnectOptions.Nkey = "U_FORGE\n[INF] forged %s\u001b]0;pwned\u0007"
+	rc.ConnectOptions.SignedNonce = "AAAA"
+
+	_, err = authenticator.TryAuthenticate(context.Background(), rc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "NKey not found in permissions config")
+	assert.NotContains(t, err.Error(), "[INF] forged")
+	assert.NotContains(t, err.Error(), "%s")
+	assert.NotContains(t, err.Error(), "\u001b")
+	assert.NotContains(t, err.Error(), "\n")
+}
+
+func TestNKeyAuthenticateDoesNotEchoUnknownPublicKey(t *testing.T) {
+	permFile := createTestPermissionsFile(t)
+	defer os.Remove(permFile)
+
+	pm, err := config.NewPermissionsManager(permFile, testLogger())
+	require.NoError(t, err)
+	defer pm.Close()
+
+	kp, err := nkeys.CreateUser()
+	require.NoError(t, err)
+	publicKey, err := kp.PublicKey()
+	require.NoError(t, err)
+
+	authenticator := NewNKeyAuthenticator(pm, testLogger(), testServiceName)
+
+	_, err = authenticator.Authenticate(context.Background(), publicKey)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "NKey not found in permissions config")
+	assert.NotContains(t, err.Error(), publicKey)
+}
+
 // TestNoAuthAuthentication tests NoAuth authentication
 func TestNoAuthAuthentication(t *testing.T) {
 	// Create test config with noauth enabled

--- a/auth-callout/src/internal/auth/nkey.go
+++ b/auth-callout/src/internal/auth/nkey.go
@@ -73,7 +73,7 @@ func (n *NKeyAuthenticator) Authenticate(ctx context.Context, publicKey string) 
 				attribute.String("reason", "user_not_found"),
 			))
 		}
-		return nil, fmt.Errorf("NKey not found in permissions config: %s", publicKey)
+		return nil, fmt.Errorf("NKey not found in permissions config")
 	}
 
 	n.logger.Info("NKey authentication successful",
@@ -129,7 +129,7 @@ func (n *NKeyAuthenticator) TryAuthenticate(ctx context.Context, rc *natsjwt.Aut
 				attribute.String("reason", "user_not_found"),
 			))
 		}
-		return config.UserProfile{}, fmt.Errorf("NKey not found in permissions config: %s", userNKey)
+		return config.UserProfile{}, fmt.Errorf("NKey not found in permissions config")
 	}
 
 	// Verify the signature

--- a/auth-callout/src/internal/service/service.go
+++ b/auth-callout/src/internal/service/service.go
@@ -35,6 +35,10 @@ const (
 	natsClientName         = "auth-callout-service"
 	natsStartupConnectWait = 2 * time.Second
 	natsMaxReconnects      = -1 // Keep retrying while readiness reports NATS unavailable.
+	httpReadHeaderTimeout  = 5 * time.Second
+	httpReadTimeout        = 10 * time.Second
+	httpWriteTimeout       = 10 * time.Second
+	httpIdleTimeout        = 120 * time.Second
 )
 
 // Service wraps HTTP server with graceful shutdown
@@ -174,11 +178,11 @@ func New(config ServiceConfig, logger *otelzap.Logger) *Service {
 		gorillaHandlers.RecoveryLogger(zapErrorLogger),
 	)(rootRouter)
 
-	srv := &http.Server{
-		Addr:     fmt.Sprintf(":%d", config.HostConfig.Port),
-		Handler:  recoveryHandler,
-		ErrorLog: zapErrorLogger,
-	}
+	srv := newHTTPServer(
+		fmt.Sprintf(":%d", config.HostConfig.Port),
+		recoveryHandler,
+		logger.Logger,
+	)
 
 	return &Service{
 		config:         config,
@@ -190,6 +194,18 @@ func New(config ServiceConfig, logger *otelzap.Logger) *Service {
 		issuerKeyPair:  issuerKeyPair,
 		issuerPubKey:   issuerPubKey,
 		curveKeyPair:   curveKeyPair,
+	}
+}
+
+func newHTTPServer(addr string, handler http.Handler, logger *zap.Logger) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ErrorLog:          obslogging.NewLoggerWithZapWriter(logger),
+		ReadHeaderTimeout: httpReadHeaderTimeout,
+		ReadTimeout:       httpReadTimeout,
+		WriteTimeout:      httpWriteTimeout,
+		IdleTimeout:       httpIdleTimeout,
 	}
 }
 


### PR DESCRIPTION
## Summary

- removes raw NKey values from not-found auth errors while keeping the auth request path lookup-first
- adds explicit HTTP server timeouts to the auth-callout health server
- changes auth-callout logging defaults from debug/development to info/production

## Validation

- `go test -count=1 -run 'TestNKeyTryAuthenticateDoesNotEchoMalformedPublicKey|TestNKeyAuthenticateDoesNotEchoUnknownPublicKey' ./src/internal/auth`
- `go test ./src/internal/auth ./src/internal/service`
- `go test ./src/internal/service`
- `make -C auth-callout test`
- `helm template auth-callout auth-callout/deploy`
- `helm lint auth-callout/deploy`
- `helm lint deploy/nats-event-bus`
- `git diff --check`
- `make -C local setup-infra deploy-nats test-functional`

## Notes

- GitHub Actions SHA pinning, Helm lock/checksum files, custom callout logger, the plan file, and `TestNewHTTPServerSetsTimeouts` are intentionally not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message security to prevent leakage of sensitive information in authentication failures.

* **Tests**
  * Added test cases validating secure error handling for authentication scenarios.

* **Chores**
  * Updated logging configuration from debug to info level with production settings.
  * Added explicit HTTP server timeout configuration for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->