### PR TITLE
ci: align local go test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
           go-flags: "-mod=vendor"
           test-flags: "-v -count=1 -timeout=10m"
           working-directory: auth-callout
+      - name: Run integration client tests
+        working-directory: auth-callout/tests
+        run: go test -short ./...
 
   unit-test-local-mqtt:
     name: Unit Test (local/mqtt-client)
@@ -81,7 +84,7 @@ jobs:
           cache-dependency-path: local/mqtt-client/go.sum
       - name: Run tests
         working-directory: local/mqtt-client
-        run: go test ./pkg/...
+        run: go test ./pkg/... ./internal/... ./cmd/...
 
   unit-test-local-mqttbs:
     name: Unit Test (local/mqttbs)


### PR DESCRIPTION
## Summary
- Run the separate auth-callout/tests Go module in CI.
- Expand the local/mqtt-client CI command to match the top-level Makefile test scope: ./pkg/... ./internal/... ./cmd/...

## Root Cause
CI hand-rolled local Go test commands instead of matching the top-level make test target. That left auth-callout/tests untested and let local/mqtt-client internal tests be skipped.

## Validation
- yq e '.' .github/workflows/ci.yml
- git diff --check
- make -C auth-callout test
- cd auth-callout/tests && go test -short ./...
- cd local/mqttbs && go test ./...
- cd local/mqtt-client && go test ./pkg/... ./internal/... ./cmd/... fails as expected on NVBug 6253249

## Known Failure
This PR intentionally leaves the dummy BMS exemplar CSV failure unfixed so CI exposes NVBug 6253249.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to run additional integration client tests for the auth-callout job.
  * Unit-test coverage expanded for local MQTT components to include additional internal and command areas, increasing test scope and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->