### PR TITLE
docs: update README, add repo links to public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 DSX Exchange is a monorepo for DSX event bus schemas, authentication, deployment, and local evaluation tooling.
 
+Documentation for DSX Exchange is available at [https://docs.nvidia.com/dsx-exchange](https://docs.nvidia.com/dsx-exchange).
+
 ## Overview
 
 DSX Exchange provides the repository pieces needed to describe, deploy, and validate DSX MQTT event bus integrations:
@@ -25,7 +27,7 @@ make check
 
 If you already have a DSX Exchange broker and need to build or test an MQTT
 integration application, start with the
-[Integrator Quickstart](docs/integrator-quickstart.md).
+[Integrator Quickstart](https://docs.nvidia.com/dsx-exchange/integrator-quickstart).
 
 For local end-to-end validation, create the Kind environment and deploy NATS:
 
@@ -97,7 +99,6 @@ make -C local benchmark-basic-full
 - Release notes: [CHANGELOG.md](CHANGELOG.md)
 - Third-party license inventory: [THIRD_PARTY_LICENSES.csv](THIRD_PARTY_LICENSES.csv) and [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md)
 
-
 ### Versioning
 
 DSX Exchange follows [Semantic Versioning](https://semver.org/) (`vX.Y.Z`), automated via semantic-release. A new version is published automatically when a semantic-release compliant commit is merged to `main`.
@@ -108,11 +109,9 @@ DSX Exchange follows [Semantic Versioning](https://semver.org/) (`vX.Y.Z`), auto
 | `feat:` | Minor (Y) | New features, backward-compatible changes |
 | `feat!:` or `BREAKING CHANGE:` | Major (X) | Breaking API, schema, or chart changes |
 
-
 ### Roadmap
 
 Upcoming work is tracked in [GitHub Issues](https://github.com/NVIDIA/dsx-exchange/issues). See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get involved.
-
 
 ## Contribution Guidelines
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,6 +12,10 @@ DSX Exchange consists of three components:
 | AsyncAPI Schema | Formal topic definitions and payload contracts per service team |
 | Auth-Callout Service | OAuth2/mTLS/NKey authentication with topic-level ACLs |
 
+<Info title="GitHub Repository">
+  The DSX Exchange GitHub repository is available at [https://github.com/NVIDIA/dsx-exchange](https://github.com/NVIDIA/dsx-exchange).
+</Info>
+
 ## DSX Event Bus
 
 The DSX Event Bus is a [NATS](https://nats.io/) messaging platform that provides MQTT 3.1.1 connectivity, [JetStream](https://docs.nats.io/nats-concepts/jetstream) persistence, and multi-cluster [leaf node federation](https://docs.nats.io/running-a-nats-service/configuration/leafnodes) across the AI factory topology.

--- a/docs/pre-deployment.md
+++ b/docs/pre-deployment.md
@@ -4,6 +4,10 @@ Everything that must be in place before deploying the DSX Event Bus. This covers
 
 **Estimated time**: The production path (secrets pipeline + certificates) takes 4–6 hours for a first-time deployment across 1 CSC + 2 CPCs. The evaluation path (`local/` Makefile) takes ~10 minutes. See [Deployment — Evaluation Install](getting-started.md) for the quick-start option.
 
+<Info title="GitHub Repository">
+  The DSX Exchange GitHub repository is available at [https://github.com/NVIDIA/dsx-exchange](https://github.com/NVIDIA/dsx-exchange).
+</Info>
+
 ## Host Prerequisites
 
 A multi-cluster deployment (CSC + CPCs) creates enough kubelets, containerd shims, gateway controllers, and fsnotify watchers to exhaust default Linux inotify limits. Symptoms include `too many open files` from `kubectl logs -f`, silent fsnotify watcher failures, and sporadic `kubectl exec` errors.

--- a/tools/check-docs-mdx
+++ b/tools/check-docs-mdx
@@ -42,19 +42,51 @@ for dir in "${SEARCH_DIRS[@]}"; do
   while IFS= read -r file; do
     [[ -z "${file}" ]] && continue
     awk '
+      function strip_jsx_comments(input, output, start, end) {
+        output = ""
+        while (length(input) > 0) {
+          if (in_jsx_comment) {
+            end = index(input, "*/}")
+            if (end == 0) {
+              return output
+            }
+            input = substr(input, end + 3)
+            in_jsx_comment = 0
+            continue
+          }
+
+          start = index(input, "{/*")
+          if (start == 0) {
+            output = output input
+            return output
+          }
+
+          output = output substr(input, 1, start - 1)
+          input = substr(input, start + 3)
+          end = index(input, "*/}")
+          if (end == 0) {
+            in_jsx_comment = 1
+            return output
+          }
+          input = substr(input, end + 3)
+        }
+        return output
+      }
+
       /^```/ { in_fence = !in_fence; next }
       in_fence { next }
-      /[^\\]{/ {
-        line = $0
+      {
+        line = strip_jsx_comments($0)
         gsub(/`[^`]*`/, "", line)
-        if (line ~ /[^\\]{/) {
+
+        if (line ~ /(^|[^\\])\{/) {
           printf "MDX: bare { outside code fence: %s:%d: %s\n", FILENAME, NR, $0
           errors++
         }
-      }
-      /<!--/ {
-        printf "MDX: HTML comment outside code fence: %s:%d: %s\n", FILENAME, NR, $0
-        errors++
+        if (line ~ /<!--/) {
+          printf "MDX: HTML comment outside code fence: %s:%d: %s\n", FILENAME, NR, $0
+          errors++
+        }
       }
       END { exit (errors > 0) ? 1 : 0 }
     ' "$file" 2>/dev/null


### PR DESCRIPTION
## Description

Add links from README to published docs, and from public docs to the GitHub repo.

## Validation

The docs lint cleanly, and the site builds correctly. :)

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/dsx-exchange/blob/main/CONTRIBUTING.md).
- [x] Documentation updated, if needed.
- [x] Tests or validation added/updated, if needed.
- [x] License headers are present on applicable source files.
- [x] Third-party license inventory updated, if dependencies changed.
- [x] Security-sensitive changes were reviewed privately before public disclosure.
- [x] My commits are signed off (`git commit -s`) per the DCO.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README with revised documentation links and improved section layout
  * Added GitHub repository links to architecture and pre-deployment pages
  * Improved spacing and consistency across documentation sections

* **Chores**
  * Enhanced documentation validation to correctly handle JSX-style comments in MDX checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->