### PR TITLE
fix(ci): check license headers repo-wide

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 reviews:
   auto_review:
@@ -7,3 +10,23 @@ reviews:
       - ".*"
     auto_incremental_review: true
     auto_pause_after_reviewed_commits: 0
+  pre_merge_checks:
+    docstrings:
+      mode: warning
+      threshold: 80
+  finishing_touches:
+    docstrings:
+      enabled: true
+  tools:
+    golangci-lint:
+      enabled: true
+      config_file: "auth-callout/.golangci.yml"
+
+code_generation:
+  docstrings:
+    path_instructions:
+      - path: "**/*"
+        instructions: |
+          Keep docstrings selective and short. Document non-obvious what or why;
+          do not restate signatures, parameters, returns, or control flow that
+          are clear from skimming the code.

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 name: Bug Report
 description: Report a reproducible problem.
 title: "[Bug]: "

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability report

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 name: Feature Request
 description: Propose a new capability or behavior change.
 title: "[Feature]: "

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 name: Task
 description: Track maintenance, documentation, or validation work.
 title: "[Task]: "

--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,2 +1,5 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 enabled: true
 auto_sync_draft: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
           license: apache
           copyright-holder: "NVIDIA CORPORATION & AFFILIATES. All rights reserved."
           year: "2026"
-          paths: "auth-callout/src/ deploy/ local/ schemas/"
-          ignore: "**/vendor/**,**/tests/**,auth-callout/tests/**"
+          paths: "."
+          ignore: ".git/**,**/*.md,**/*.png,**/*.sum,**/go.mod,**/tmp/**,**/vendor/**,auth-callout/vault-agent/templates/**,docs/schema-viewer/**,LICENSE,THIRD_PARTY_LICENSES*"
           go-version: "1.25.5"
 
   go-lint:

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # toml-language-server: $schema=https://raw.githubusercontent.com/rvben/rumdl/main/rumdl.schema.json
 
 # rumdl configuration file

--- a/Makefile
+++ b/Makefile
@@ -3,24 +3,11 @@
 
 .PHONY: add-license-headers check check-license-headers clean-e2e dummy-bms e2e-kind help install-e2e-prereqs test test-e2e test-helm third-party-licenses
 
-COPYRIGHT_HOLDER := NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-COPYRIGHT_YEAR := 2026
-LICENSE_TARGETS := local schemas
-LICENSE_IGNORES := \
-	-ignore "**/*.png" \
-	-ignore "**/go.sum" \
-	-ignore "**/tests/performance/reports/**" \
-	-ignore "**/vendor/**"
-
 add-license-headers: ## Add SPDX license headers across repository sources
-	addlicense -l apache -c "$(COPYRIGHT_HOLDER)" -s=only -y "$(COPYRIGHT_YEAR)" $(LICENSE_IGNORES) -v $(LICENSE_TARGETS)
-	$(MAKE) -C auth-callout add-license-headers
-	$(MAKE) -C deploy add-license-headers
+	bash scripts/license.sh fix
 
 check-license-headers: ## Verify SPDX license headers across repository sources
-	addlicense -l apache -c "$(COPYRIGHT_HOLDER)" -s=only -y "$(COPYRIGHT_YEAR)" $(LICENSE_IGNORES) -check $(LICENSE_TARGETS)
-	$(MAKE) -C auth-callout check-license-headers
-	$(MAKE) -C deploy check-license-headers
+	bash scripts/license.sh check
 
 check: check-license-headers test test-helm ## Run all local validation checks
 

--- a/auth-callout/.air.toml
+++ b/auth-callout/.air.toml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 root = "."
 testdata_dir = "testdata"
 tmp_dir = "tmp"

--- a/auth-callout/.pre-commit-config.yaml
+++ b/auth-callout/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 

--- a/auth-callout/.spectral-extension.yml
+++ b/auth-callout/.spectral-extension.yml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 ruleset_overrides:                                                        # Enables override of specific rule severity (per ruleset). Naming must match one to one.
   standard-owasp:
     owasp:api8:2023-no-scheme-http: "warn"

--- a/auth-callout/Makefile
+++ b/auth-callout/Makefile
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Auth-callout Service Makefile
 
 .PHONY: add-license-headers build check-license-headers clean clean-modcache deps-update dev dev-build dev-debug dev-debug-suspend dev-debug-suspend-with-delve-logs dev-debug-with-delve-logs dev-lint devspace-all devspace-macos docker-build docker-run fmt godoc help init-hooks init-project install-tools lint pre-commit-run release run run-service test test-helm test-integration test-integration-devspace third-party-licenses version
@@ -11,8 +14,6 @@ TEST_FLAGS=-race -v -count 1
 GOCMD=go
 GO_LICENSES_VERSION=v1.6.0
 ADDLICENSE_VERSION=v1.2.0
-COPYRIGHT_HOLDER=NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-COPYRIGHT_YEAR=2026
 GIT_HOOKS_DIR=$(shell git rev-parse --git-path hooks 2>/dev/null || echo .git/hooks)
 TOOLS_BIN=$(CURDIR)/tmp/bin
 GO_LICENSES=$(TOOLS_BIN)/go-licenses
@@ -215,10 +216,10 @@ test-integration-devspace:  ## Run integration tests against devspace cluster
 	cd tests && go mod tidy && AUTH_CALLOUT_SERVICE_URL=http://auth-callout.127-0-0-1.nip.io:8080 go test $(TEST_FLAGS) ./...
 
 add-license-headers: ## Add SPDX license headers to source files
-	addlicense -l apache -c "$(COPYRIGHT_HOLDER)" -s=only -y $(COPYRIGHT_YEAR) -ignore "vendor/**" -ignore "tests/**" -v src/
+	bash ../scripts/license.sh fix
 
 check-license-headers: ## Verify SPDX license headers are present
-	addlicense -l apache -c "$(COPYRIGHT_HOLDER)" -s=only -y $(COPYRIGHT_YEAR) -ignore "vendor/**" -ignore "tests/**" -check src/
+	bash ../scripts/license.sh check
 
 $(GO_LICENSES):
 	@mkdir -p "$(TOOLS_BIN)"

--- a/auth-callout/build/package/Dockerfile
+++ b/auth-callout/build/package/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 ################################################################################
 ### Build arguments
 ################################################################################

--- a/auth-callout/deploy/Chart.yaml
+++ b/auth-callout/deploy/Chart.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v2
 name: auth-callout
 description: A Helm chart for Kubernetes

--- a/auth-callout/deploy/files/vault-annotations.yaml
+++ b/auth-callout/deploy/files/vault-annotations.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if .Values.vault.enabled }}
 # Vault Sidecar Injection Annotations
 vault.hashicorp.com/agent-inject: "true"

--- a/auth-callout/deploy/templates/configmap.yaml
+++ b/auth-callout/deploy/templates/configmap.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/auth-callout/deploy/templates/deployment.yaml
+++ b/auth-callout/deploy/templates/deployment.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/auth-callout/deploy/templates/metrics-service.yaml
+++ b/auth-callout/deploy/templates/metrics-service.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if include "metrics.prometheusEnabled" . }}
 apiVersion: v1
 kind: Service

--- a/auth-callout/deploy/templates/permissions-configmap.yaml
+++ b/auth-callout/deploy/templates/permissions-configmap.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 {{- /*
 Permissions ConfigMap for NATS Auth Callout
 

--- a/auth-callout/deploy/templates/registry-secret.yaml
+++ b/auth-callout/deploy/templates/registry-secret.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if and (not .Values.registry.existingSecret) .Values.registry.server .Values.registry.username .Values.registry.password }}
 apiVersion: v1
 kind: Secret

--- a/auth-callout/deploy/templates/service.yaml
+++ b/auth-callout/deploy/templates/service.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/auth-callout/deploy/templates/serviceaccount.yaml
+++ b/auth-callout/deploy/templates/serviceaccount.yaml
@@ -1,4 +1,7 @@
-{{- if .Values.serviceAccount.create -}}
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/auth-callout/deploy/templates/servicemonitor.yaml
+++ b/auth-callout/deploy/templates/servicemonitor.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if and (include "metrics.prometheusEnabled" .) .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/auth-callout/deploy/templates/validation.yaml
+++ b/auth-callout/deploy/templates/validation.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 {{/*
 Validation template for configuration requirements
 This template will fail the deployment if required configurations are missing

--- a/auth-callout/deploy/values.yaml
+++ b/auth-callout/deploy/values.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Override the name and fullname of the chart
 nameOverride: ""
 fullnameOverride: ""

--- a/auth-callout/devspace.yaml
+++ b/auth-callout/devspace.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 version: v2beta1
 name: auth-callout
 

--- a/auth-callout/docs/examples/values-vault-example.yaml
+++ b/auth-callout/docs/examples/values-vault-example.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Example values file showing how to configure Vault integration
 # Copy the relevant sections to your values.yaml and customize as needed
 

--- a/auth-callout/profiles/edge.yaml
+++ b/auth-callout/profiles/edge.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 deployments:
   auth-callout:
     helm:

--- a/auth-callout/profiles/gateway.yaml
+++ b/auth-callout/profiles/gateway.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Gateway API Profile
 # Enables Gateway API routing instead of traditional Ingress
 # Gateway infrastructure is deployed by devspace-pipelines when this profile is active

--- a/auth-callout/profiles/obs.yaml
+++ b/auth-callout/profiles/obs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 deployments:
   auth-callout:
     helm:

--- a/auth-callout/profiles/vault.yaml
+++ b/auth-callout/profiles/vault.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 deployments:
   auth-callout:
     helm:

--- a/auth-callout/scripts/check-helm-version.sh
+++ b/auth-callout/scripts/check-helm-version.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 # Get all staged files under deploy/

--- a/auth-callout/scripts/check-tag-appversion.sh
+++ b/auth-callout/scripts/check-tag-appversion.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Script to validate that a tag matches appVersion in Chart.yaml
 
 set -e

--- a/auth-callout/scripts/devspace-get-key.sh
+++ b/auth-callout/scripts/devspace-get-key.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Helper script to get NATS keys for devspace variables
 # Generates keys on first access if devspace.env doesn't exist
 

--- a/auth-callout/scripts/devspace_start.sh
+++ b/auth-callout/scripts/devspace_start.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 set +e  # Continue on errors
 export LANG=en_US.UTF-8
 export TERM=xterm-256color

--- a/auth-callout/scripts/kind-load-image.sh
+++ b/auth-callout/scripts/kind-load-image.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Load a Docker image into a kind cluster.
 # Usage: kind-load-image.sh <image> [cluster-name]
 

--- a/auth-callout/scripts/test-helm-validation.sh
+++ b/auth-callout/scripts/test-helm-validation.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 # Test script for Helm chart validation
 # This script tests both valid and invalid configurations to ensure validation works correctly

--- a/auth-callout/tests/integration_test.go
+++ b/auth-callout/tests/integration_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apitests
 
 import (

--- a/auth-callout/vault-agent/config-local.hcl
+++ b/auth-callout/vault-agent/config-local.hcl
@@ -1,3 +1,6 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pid_file = "./pidfile"
 
 exit_after_auth = true

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -1,19 +1,13 @@
 # Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# NATS Event Bus Deploy Makefile
-
 .PHONY: add-license-headers check-license-headers help
 
-ADDLICENSE_VERSION=v1.2.0
-COPYRIGHT_HOLDER=NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-COPYRIGHT_YEAR=2026
-
 add-license-headers: ## Add SPDX license headers to source files
-	addlicense -l apache -c "$(COPYRIGHT_HOLDER)" -s=only -y $(COPYRIGHT_YEAR) -v .
+	bash ../scripts/license.sh fix
 
 check-license-headers: ## Verify SPDX license headers are present
-	addlicense -l apache -c "$(COPYRIGHT_HOLDER)" -s=only -y $(COPYRIGHT_YEAR) -check .
+	bash ../scripts/license.sh check
 
 help: ## Show this help message
 	@echo "Available commands:"

--- a/scripts/generate_asyncapi_docs.py
+++ b/scripts/generate_asyncapi_docs.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Generate Fern MDX pages from AsyncAPI 3.1.0 YAML specs.
 
 Reads the four AsyncAPI specs under schemas/asyncapi/ and writes native MDX

--- a/scripts/license.sh
+++ b/scripts/license.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -Eeuo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+HEADER_OWNER="NVIDIA CORPORATION & AFFILIATES. All rights reserved."
+HEADER_YEAR="2026"
+
+usage=$'Usage:\n  bash scripts/license.sh check\n  bash scripts/license.sh fix'
+
+case "${1:-}" in
+	check)
+		mode="check"
+		;;
+	fix)
+		mode="fix"
+		;;
+	-h|--help|help|'')
+		echo "${usage}"
+		;;
+	*)
+		echo "${usage}"
+		exit 2
+		;;
+esac
+
+[[ -n "${mode:-}" ]] || exit 0
+
+if ! command -v addlicense >/dev/null 2>&1; then
+	echo "license: addlicense is required" >&2
+	exit 1
+fi
+
+args=(
+	-c "${HEADER_OWNER}"
+	-y "${HEADER_YEAR}"
+	-l apache
+	-s=only
+	-ignore '.git/**'
+	-ignore '**/*.md'
+	-ignore '**/*.png'
+	-ignore '**/*.sum'
+	-ignore '**/go.mod'
+	-ignore '**/tmp/**'
+	-ignore '**/vendor/**'
+	-ignore 'auth-callout/vault-agent/templates/**'
+	-ignore 'docs/schema-viewer/**'
+	-ignore 'LICENSE'
+	-ignore 'THIRD_PARTY_LICENSES*'
+)
+[[ "${mode}" == "check" ]] && args=(-check "${args[@]}")
+
+addlicense "${args[@]}" .


### PR DESCRIPTION
## Summary

- centralize local license header add/check entrypoints behind `scripts/license.sh`
- keep CI on the pinned NVIDIA `license-headers` action, widened to the repository instead of narrow path lists
- configure CodeRabbit to keep docstring coverage active while generating only short non-obvious what/why docs
- point CodeRabbit golangci-lint at the existing auth-callout module config instead of relying on root config discovery
- add SPDX headers to source/config files that the previous local/CI target missed, including auth-callout chart values/templates and devspace/config files

## Root Cause

The local and CI license-header checks only covered selected paths. In particular, `auth-callout/src/` was checked but chart YAML and DevSpace/config files under `auth-callout/` were not, matching the repeated CodeRabbit SPDX comments on recent PRs.

The new license wrapper also should not create obvious shell helper functions that require useless docstrings. It now uses straight-line dispatch, and CodeRabbit keeps its docstring coverage check enabled at the default 80% warning threshold.

This repo has multiple independent Go modules and no root `go.mod`. CodeRabbit's golangci-lint integration is left enabled, but pointed at `auth-callout/.golangci.yml`, matching the CI linted module.

## Validation

- `yq '.' .coderabbit.yaml >/dev/null`
- `yq '.' .github/workflows/ci.yml >/dev/null`
- `bash -n scripts/license.sh`
- `make check-license-headers`
- `make -C deploy check-license-headers`
- `make -C auth-callout check-license-headers`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --config .golangci.yml ./...` from `auth-callout/`
- `git diff --check`
- `make check`
- adversarial subagent review; latest actionable finding addressed by moving `deploy/Makefile` onto `scripts/license.sh`
- clean local e2e from subagent after rebase: `make clean-e2e e2e-kind`
  - functional suite passed: `ok github.com/NVIDIA/dsx-exchange/local/mqtt-client/tests/functional 39.409s`
  - performance smoke passed: `Test Summary: 12 passed, 0 failed out of 12 total`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Apache-2.0 license headers across the repository for compliance
  * Centralized license header management into a shared script and updated build tooling to use it
  * Expanded CI validation to check license headers across the entire repository
  * Introduced docstring checks (warning threshold) and guidance for concise generated docstrings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->