### PR TITLE
fix(docs): correct entity output in asyncapi doc script

### DIFF
--- a/docs/schema-bms-ahu-metadata.mdx
+++ b/docs/schema-bms-ahu-metadata.mdx
@@ -44,7 +44,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -90,7 +90,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -120,7 +120,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -150,7 +150,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -183,7 +183,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -232,7 +232,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -278,7 +278,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -308,7 +308,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -338,7 +338,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -368,7 +368,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -401,7 +401,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -447,7 +447,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -477,7 +477,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -507,7 +507,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -537,7 +537,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -570,7 +570,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -621,7 +621,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 

--- a/docs/schema-bms-ats-metadata.mdx
+++ b/docs/schema-bms-ats-metadata.mdx
@@ -44,7 +44,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -93,7 +93,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -144,7 +144,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 

--- a/docs/schema-bms-bess-metadata.mdx
+++ b/docs/schema-bms-bess-metadata.mdx
@@ -44,7 +44,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -93,7 +93,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -144,7 +144,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 

--- a/docs/schema-bms-breaker-metadata.mdx
+++ b/docs/schema-bms-breaker-metadata.mdx
@@ -44,7 +44,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -93,7 +93,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -144,7 +144,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 

--- a/docs/schema-bms-cdu-metadata.mdx
+++ b/docs/schema-bms-cdu-metadata.mdx
@@ -45,7 +45,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -91,7 +91,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -121,7 +121,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -151,7 +151,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -184,7 +184,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -233,7 +233,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -279,7 +279,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -309,7 +309,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -339,7 +339,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -369,7 +369,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -402,7 +402,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -448,7 +448,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -478,7 +478,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -508,7 +508,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -538,7 +538,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -571,7 +571,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -620,7 +620,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -671,7 +671,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 

--- a/docs/schema-bms-chiller-metadata.mdx
+++ b/docs/schema-bms-chiller-metadata.mdx
@@ -44,7 +44,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -90,7 +90,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -120,7 +120,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -150,7 +150,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -183,7 +183,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -232,7 +232,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -278,7 +278,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -308,7 +308,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -338,7 +338,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -368,7 +368,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -401,7 +401,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -447,7 +447,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -477,7 +477,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -507,7 +507,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -537,7 +537,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -570,7 +570,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -621,7 +621,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 

--- a/docs/schema-bms-coolingtower-metadata.mdx
+++ b/docs/schema-bms-coolingtower-metadata.mdx
@@ -44,7 +44,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -90,7 +90,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -120,7 +120,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -150,7 +150,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -183,7 +183,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -232,7 +232,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -278,7 +278,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -308,7 +308,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -338,7 +338,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -368,7 +368,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -401,7 +401,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -447,7 +447,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -477,7 +477,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -507,7 +507,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -537,7 +537,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -570,7 +570,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -621,7 +621,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 

--- a/docs/schema-bms-crac-metadata.mdx
+++ b/docs/schema-bms-crac-metadata.mdx
@@ -44,7 +44,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -90,7 +90,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -120,7 +120,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -150,7 +150,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -183,7 +183,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -232,7 +232,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -278,7 +278,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -308,7 +308,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -338,7 +338,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -368,7 +368,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -401,7 +401,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -447,7 +447,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -477,7 +477,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -507,7 +507,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -537,7 +537,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -570,7 +570,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -621,7 +621,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 

--- a/docs/schema-bms-crah-metadata.mdx
+++ b/docs/schema-bms-crah-metadata.mdx
@@ -44,7 +44,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -90,7 +90,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -120,7 +120,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -150,7 +150,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -183,7 +183,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -232,7 +232,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -278,7 +278,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -308,7 +308,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -338,7 +338,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -368,7 +368,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -401,7 +401,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -447,7 +447,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -477,7 +477,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -507,7 +507,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -537,7 +537,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -570,7 +570,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -621,7 +621,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 

--- a/docs/schema-bms-damper-metadata.mdx
+++ b/docs/schema-bms-damper-metadata.mdx
@@ -41,7 +41,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -74,7 +74,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -125,7 +125,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 

--- a/docs/schema-bms-fan-metadata.mdx
+++ b/docs/schema-bms-fan-metadata.mdx
@@ -41,7 +41,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -74,7 +74,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -125,7 +125,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 

--- a/docs/schema-bms-generator-metadata.mdx
+++ b/docs/schema-bms-generator-metadata.mdx
@@ -44,7 +44,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -93,7 +93,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -144,7 +144,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 

--- a/docs/schema-bms-genericobject-metadata.mdx
+++ b/docs/schema-bms-genericobject-metadata.mdx
@@ -45,7 +45,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -91,7 +91,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -121,7 +121,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -151,7 +151,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -184,7 +184,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -233,7 +233,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -279,7 +279,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -309,7 +309,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -339,7 +339,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -369,7 +369,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -402,7 +402,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -448,7 +448,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -478,7 +478,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -508,7 +508,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -538,7 +538,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -571,7 +571,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -620,7 +620,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -669,7 +669,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -720,7 +720,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 

--- a/docs/schema-bms-hx-metadata.mdx
+++ b/docs/schema-bms-hx-metadata.mdx
@@ -44,7 +44,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -90,7 +90,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -120,7 +120,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -150,7 +150,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -183,7 +183,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -232,7 +232,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -278,7 +278,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -308,7 +308,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -338,7 +338,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -368,7 +368,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -401,7 +401,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -447,7 +447,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -477,7 +477,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -507,7 +507,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -537,7 +537,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -570,7 +570,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -621,7 +621,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 

--- a/docs/schema-bms-messages.mdx
+++ b/docs/schema-bms-messages.mdx
@@ -110,7 +110,7 @@ metadata message.
 | `pointType` | string | Yes | Values: `RackLeakDetect` |
 | `rackLocationName` | string | Yes | Human-readable rack name as defined by the BMS. |
 | `rackLocationId` | string | Yes | Stable unique identifier for the rack. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for leak detection. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for leak detection. |
 
 ---
 
@@ -124,7 +124,7 @@ metadata message.
 | `pointType` | string | Yes | Values: `RackLeakSensorFault` |
 | `rackLocationName` | string | Yes | Human-readable rack name as defined by the BMS. |
 | `rackLocationId` | string | Yes | Stable unique identifier for the rack. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for leak sensor fault status. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for leak sensor fault status. |
 
 ---
 
@@ -138,7 +138,7 @@ metadata message.
 | `pointType` | string | Yes | Values: `RackLiquidIsolationStatus` |
 | `rackLocationName` | string | Yes | Human-readable rack name as defined by the BMS. |
 | `rackLocationId` | string | Yes | Stable unique identifier for the rack. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for liquid isolation status. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for liquid isolation status. |
 
 ---
 
@@ -152,7 +152,7 @@ metadata message.
 | `pointType` | string | Yes | Values: `RackElectricalIsolationStatus` |
 | `rackLocationName` | string | Yes | Human-readable rack name as defined by the BMS. |
 | `rackLocationId` | string | Yes | Stable unique identifier for the rack. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for electrical isolation status. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for electrical isolation status. |
 
 ---
 
@@ -167,7 +167,7 @@ metadata message.
 | `rackLocationName` | string | Yes | Human-readable rack name as defined by the BMS. |
 | `rackLocationId` | string | Yes | Stable unique identifier for the rack. |
 | `integration` | string | Yes | Integration identifier responsible for publishing this value. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for tray leak detection. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for tray leak detection. |
 
 ---
 
@@ -182,7 +182,7 @@ metadata message.
 | `rackLocationName` | string | Yes | Human-readable rack name as defined by the BMS. |
 | `rackLocationId` | string | Yes | Stable unique identifier for the rack. |
 | `integration` | string | Yes | Integration identifier responsible for publishing this value. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for liquid isolation request. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for liquid isolation request. |
 
 ---
 
@@ -197,7 +197,7 @@ metadata message.
 | `rackLocationName` | string | Yes | Human-readable rack name as defined by the BMS. |
 | `rackLocationId` | string | Yes | Stable unique identifier for the rack. |
 | `integration` | string | Yes | Integration identifier responsible for publishing this value. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for electrical isolation request. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for electrical isolation request. |
 
 ---
 
@@ -211,7 +211,7 @@ metadata message.
 | `pointType` | string | Yes | Values: `Voltage` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 | `engUnit` | string | Yes |  |
 
 ---
@@ -226,7 +226,7 @@ metadata message.
 | `pointType` | string | Yes | Values: `PowerFactor` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 
 ---
 
@@ -240,7 +240,7 @@ metadata message.
 | `pointType` | string | Yes | Values: `Frequency` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 | `engUnit` | string | Yes |  |
 
 ---
@@ -255,7 +255,7 @@ metadata message.
 | `pointType` | string | Yes | Values: `ApparentPower` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 | `engUnit` | string | Yes |  |
 
 ---
@@ -270,7 +270,7 @@ metadata message.
 | `pointType` | string | Yes | Values: `ActivePower` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 | `engUnit` | string | Yes |  |
 
 ---
@@ -285,7 +285,7 @@ metadata message.
 | `pointType` | string | Yes | Values: `Current` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 | `engUnit` | string | Yes |  |
 
 ---
@@ -300,7 +300,7 @@ metadata message.
 | `pointType` | string | Yes | Values: `CurrentLimit` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 | `engUnit` | string | Yes |  |
 
 ---
@@ -315,7 +315,7 @@ metadata message.
 | `pointType` | string | Yes | Values: `PhaseCurrent` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 | `engUnit` | string | Yes |  |
 | `phase` | string | Yes | Electrical phase identifier. Letter form (A/B/C) and numeric form (1/2/3) are both accepted to align with publisher conventions. Values: `A`, `B`, `C`, `1`, `2`, `3` |
 
@@ -340,7 +340,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -372,7 +372,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -392,7 +392,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -412,7 +412,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -435,7 +435,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -470,7 +470,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -502,7 +502,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -522,7 +522,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -542,7 +542,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -562,7 +562,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -585,7 +585,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -617,7 +617,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -637,7 +637,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -657,7 +657,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -680,7 +680,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -715,7 +715,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -806,7 +806,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -841,7 +841,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -876,7 +876,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -911,7 +911,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -946,7 +946,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -981,7 +981,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1016,7 +1016,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1051,7 +1051,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1086,7 +1086,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1121,7 +1121,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1156,7 +1156,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1191,7 +1191,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1226,7 +1226,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1261,7 +1261,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1293,7 +1293,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -1313,7 +1313,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -1333,7 +1333,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -1353,7 +1353,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -1376,7 +1376,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1408,7 +1408,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -1428,7 +1428,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -1448,7 +1448,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -1471,7 +1471,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1503,7 +1503,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -1523,7 +1523,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -1543,7 +1543,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -1566,7 +1566,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1601,7 +1601,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1636,7 +1636,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1671,7 +1671,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1706,7 +1706,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1741,7 +1741,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1776,7 +1776,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1811,7 +1811,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1846,7 +1846,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1881,7 +1881,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1916,7 +1916,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1951,7 +1951,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1986,7 +1986,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2021,7 +2021,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2056,7 +2056,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2091,7 +2091,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2123,7 +2123,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2143,7 +2143,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2163,7 +2163,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2183,7 +2183,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2203,7 +2203,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2223,7 +2223,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2243,7 +2243,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2263,7 +2263,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2283,7 +2283,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2303,7 +2303,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2341,7 +2341,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2373,7 +2373,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2393,7 +2393,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2413,7 +2413,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2436,7 +2436,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2471,7 +2471,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2503,7 +2503,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2523,7 +2523,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2543,7 +2543,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2563,7 +2563,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2586,7 +2586,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2618,7 +2618,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2638,7 +2638,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2658,7 +2658,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2681,7 +2681,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2713,7 +2713,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2733,7 +2733,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2753,7 +2753,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2776,7 +2776,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2811,7 +2811,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2843,7 +2843,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2863,7 +2863,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2883,7 +2883,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2903,7 +2903,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2926,7 +2926,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2958,7 +2958,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2978,7 +2978,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2998,7 +2998,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3021,7 +3021,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3053,7 +3053,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3073,7 +3073,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3093,7 +3093,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3116,7 +3116,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3151,7 +3151,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3183,7 +3183,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3203,7 +3203,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3223,7 +3223,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3243,7 +3243,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3266,7 +3266,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3298,7 +3298,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3318,7 +3318,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3338,7 +3338,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3361,7 +3361,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3393,7 +3393,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3413,7 +3413,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3433,7 +3433,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3456,7 +3456,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3491,7 +3491,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3523,7 +3523,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3543,7 +3543,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3563,7 +3563,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3583,7 +3583,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3606,7 +3606,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3638,7 +3638,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3658,7 +3658,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3678,7 +3678,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3701,7 +3701,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3733,7 +3733,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3753,7 +3753,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3773,7 +3773,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3796,7 +3796,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3831,7 +3831,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3863,7 +3863,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3883,7 +3883,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3903,7 +3903,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3923,7 +3923,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3946,7 +3946,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3978,7 +3978,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3998,7 +3998,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4018,7 +4018,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4041,7 +4041,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4073,7 +4073,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4093,7 +4093,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4113,7 +4113,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4136,7 +4136,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4171,7 +4171,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4203,7 +4203,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4223,7 +4223,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4243,7 +4243,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4263,7 +4263,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4286,7 +4286,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4318,7 +4318,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4338,7 +4338,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4358,7 +4358,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4381,7 +4381,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4413,7 +4413,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4433,7 +4433,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4453,7 +4453,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4476,7 +4476,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4511,7 +4511,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4543,7 +4543,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4563,7 +4563,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4583,7 +4583,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4603,7 +4603,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4626,7 +4626,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4658,7 +4658,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4678,7 +4678,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4698,7 +4698,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4723,7 +4723,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4757,7 +4757,7 @@ Field fragment for a vendor-specific or unmapped GenericPoint. `processArea` is 
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | No | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | No | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4780,7 +4780,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4812,7 +4812,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4832,7 +4832,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4852,7 +4852,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4875,7 +4875,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4910,7 +4910,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4942,7 +4942,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4962,7 +4962,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4982,7 +4982,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5002,7 +5002,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5025,7 +5025,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -5057,7 +5057,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5077,7 +5077,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5097,7 +5097,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5120,7 +5120,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -5152,7 +5152,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5172,7 +5172,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5192,7 +5192,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5215,7 +5215,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -5250,7 +5250,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -5282,7 +5282,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5302,7 +5302,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5322,7 +5322,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5342,7 +5342,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5365,7 +5365,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -5397,7 +5397,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5417,7 +5417,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5437,7 +5437,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5460,7 +5460,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -5495,7 +5495,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 

--- a/docs/schema-bms-powermeter-metadata.mdx
+++ b/docs/schema-bms-powermeter-metadata.mdx
@@ -35,7 +35,7 @@ BMS-published metadata for all PowerMeter points.
 | `pointType` | string | Yes | Values: `Voltage` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 | `engUnit` | string | Yes |  |
 
 <Accordion title="Example payload">
@@ -67,7 +67,7 @@ BMS-published metadata for all PowerMeter points.
 | `pointType` | string | Yes | Values: `PowerFactor` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 
 <Accordion title="Example payload">
 
@@ -97,7 +97,7 @@ BMS-published metadata for all PowerMeter points.
 | `pointType` | string | Yes | Values: `Frequency` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 | `engUnit` | string | Yes |  |
 
 <Accordion title="Example payload">
@@ -129,7 +129,7 @@ BMS-published metadata for all PowerMeter points.
 | `pointType` | string | Yes | Values: `ApparentPower` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 | `engUnit` | string | Yes |  |
 
 <Accordion title="Example payload">
@@ -161,7 +161,7 @@ BMS-published metadata for all PowerMeter points.
 | `pointType` | string | Yes | Values: `ActivePower` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 | `engUnit` | string | Yes |  |
 
 <Accordion title="Example payload">
@@ -193,7 +193,7 @@ BMS-published metadata for all PowerMeter points.
 | `pointType` | string | Yes | Values: `Current` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 | `engUnit` | string | Yes |  |
 
 <Accordion title="Example payload">
@@ -225,7 +225,7 @@ BMS-published metadata for all PowerMeter points.
 | `pointType` | string | Yes | Values: `CurrentLimit` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 | `engUnit` | string | Yes |  |
 
 <Accordion title="Example payload">
@@ -257,7 +257,7 @@ BMS-published metadata for all PowerMeter points.
 | `pointType` | string | Yes | Values: `PhaseCurrent` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 | `engUnit` | string | Yes |  |
 | `phase` | string | Yes | Electrical phase identifier. Letter form (A/B/C) and numeric form (1/2/3) are both accepted to align with publisher conventions. Values: `A`, `B`, `C`, `1`, `2`, `3` |
 
@@ -299,7 +299,7 @@ Field fragment for a vendor-specific or unmapped GenericPoint. `processArea` is 
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | No | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | No | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 

--- a/docs/schema-bms-pump-metadata.mdx
+++ b/docs/schema-bms-pump-metadata.mdx
@@ -41,7 +41,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -74,7 +74,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -125,7 +125,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 

--- a/docs/schema-bms-rack-metadata.mdx
+++ b/docs/schema-bms-rack-metadata.mdx
@@ -234,7 +234,7 @@ Includes integration-owned points which carries the `integration` field.
 | `pointType` | string | Yes | Values: `RackLeakDetect` |
 | `rackLocationName` | string | Yes | Human-readable rack name as defined by the BMS. |
 | `rackLocationId` | string | Yes | Stable unique identifier for the rack. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for leak detection. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for leak detection. |
 
 <Accordion title="Example payload">
 
@@ -271,7 +271,7 @@ Includes integration-owned points which carries the `integration` field.
 | `pointType` | string | Yes | Values: `RackLeakSensorFault` |
 | `rackLocationName` | string | Yes | Human-readable rack name as defined by the BMS. |
 | `rackLocationId` | string | Yes | Stable unique identifier for the rack. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for leak sensor fault status. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for leak sensor fault status. |
 
 <Accordion title="Example payload">
 
@@ -309,7 +309,7 @@ Includes integration-owned points which carries the `integration` field.
 | `rackLocationName` | string | Yes | Human-readable rack name as defined by the BMS. |
 | `rackLocationId` | string | Yes | Stable unique identifier for the rack. |
 | `integration` | string | Yes | Integration identifier responsible for publishing this value. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for tray leak detection. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for tray leak detection. |
 
 <Accordion title="Example payload">
 
@@ -347,7 +347,7 @@ Includes integration-owned points which carries the `integration` field.
 | `pointType` | string | Yes | Values: `RackLiquidIsolationStatus` |
 | `rackLocationName` | string | Yes | Human-readable rack name as defined by the BMS. |
 | `rackLocationId` | string | Yes | Stable unique identifier for the rack. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for liquid isolation status. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for liquid isolation status. |
 
 <Accordion title="Example payload">
 
@@ -384,7 +384,7 @@ Includes integration-owned points which carries the `integration` field.
 | `pointType` | string | Yes | Values: `RackElectricalIsolationStatus` |
 | `rackLocationName` | string | Yes | Human-readable rack name as defined by the BMS. |
 | `rackLocationId` | string | Yes | Stable unique identifier for the rack. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for electrical isolation status. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for electrical isolation status. |
 
 <Accordion title="Example payload">
 
@@ -422,7 +422,7 @@ Includes integration-owned points which carries the `integration` field.
 | `rackLocationName` | string | Yes | Human-readable rack name as defined by the BMS. |
 | `rackLocationId` | string | Yes | Stable unique identifier for the rack. |
 | `integration` | string | Yes | Integration identifier responsible for publishing this value. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for liquid isolation request. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for liquid isolation request. |
 
 <Accordion title="Example payload">
 
@@ -461,7 +461,7 @@ Includes integration-owned points which carries the `integration` field.
 | `rackLocationName` | string | Yes | Human-readable rack name as defined by the BMS. |
 | `rackLocationId` | string | Yes | Stable unique identifier for the rack. |
 | `integration` | string | Yes | Integration identifier responsible for publishing this value. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for electrical isolation request. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for electrical isolation request. |
 
 <Accordion title="Example payload">
 

--- a/docs/schema-bms-schemas.mdx
+++ b/docs/schema-bms-schemas.mdx
@@ -27,7 +27,7 @@ Required for state/status/alarm points that carry no engineering unit.
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -57,7 +57,7 @@ Optional fields common to all generic equipment metadata, regardless of identifi
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -80,7 +80,7 @@ PowerMeter-specific identifier fields added to all PowerMeter metadata messages.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 
 ---
 
@@ -90,7 +90,7 @@ Optional fields common to all generic equipment metadata, regardless of identifi
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `processArea` | array\&lt;string\> | No | List of process areas or sub-system locations within the equipment |
+| `processArea` | array&lt;string&gt; | No | List of process areas or sub-system locations within the equipment |
 
 ---
 
@@ -110,7 +110,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ---
 
@@ -188,7 +188,7 @@ PowerMeter-specific identifier fields added to all PowerMeter metadata messages.
 | `pointType` | string | Yes | Canonical point type. Matches the pointType MQTT topic segment. |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 
 ---
 
@@ -211,7 +211,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -246,7 +246,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -406,7 +406,7 @@ Valid pointType values for Integration-published System points.
 |------|------|----------|-------------|
 | `pointType` | string | No | Values: `RackLeakDetect` |
 | `objectType` | string | No | Values: `Rack` |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for leak detection. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for leak detection. |
 
 ---
 
@@ -418,7 +418,7 @@ Valid pointType values for Integration-published System points.
 |------|------|----------|-------------|
 | `pointType` | string | No | Values: `RackLeakSensorFault` |
 | `objectType` | string | No | Values: `Rack` |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for leak sensor fault status. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for leak sensor fault status. |
 
 ---
 
@@ -430,7 +430,7 @@ Valid pointType values for Integration-published System points.
 |------|------|----------|-------------|
 | `pointType` | string | No | Values: `RackLiquidIsolationStatus` |
 | `objectType` | string | No | Values: `Rack` |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for liquid isolation status. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for liquid isolation status. |
 
 ---
 
@@ -442,7 +442,7 @@ Valid pointType values for Integration-published System points.
 |------|------|----------|-------------|
 | `pointType` | string | No | Values: `RackElectricalIsolationStatus` |
 | `objectType` | string | No | Values: `Rack` |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for electrical isolation status. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for electrical isolation status. |
 
 ---
 
@@ -454,7 +454,7 @@ Valid pointType values for Integration-published System points.
 |------|------|----------|-------------|
 | `pointType` | string | No | Values: `RackLeakDetectTray` |
 | `objectType` | string | No | Values: `Rack` |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for tray leak detection. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for tray leak detection. |
 
 ---
 
@@ -466,7 +466,7 @@ Valid pointType values for Integration-published System points.
 |------|------|----------|-------------|
 | `pointType` | string | No | Values: `RackLiquidIsolationRequest` |
 | `objectType` | string | No | Values: `Rack` |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for liquid isolation request. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for liquid isolation request. |
 
 ---
 
@@ -478,7 +478,7 @@ Valid pointType values for Integration-published System points.
 |------|------|----------|-------------|
 | `pointType` | string | No | Values: `RackElectricalIsolationRequest` |
 | `objectType` | string | No | Values: `Rack` |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for electrical isolation request. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for electrical isolation request. |
 
 ---
 
@@ -615,7 +615,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 |------|------|----------|-------------|
 | `pointType` | string | No | Values: `Status` |
 | `integration` | string | No | Optional integration identifier. When present, this integration is responsible for publishing the value for this point. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for operating status (values vary by equipment vendor). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for operating status (values vary by equipment vendor). |
 
 ---
 
@@ -625,7 +625,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 |------|------|----------|-------------|
 | `pointType` | string | No | Values: `Available` |
 | `integration` | string | No | Optional integration identifier. When present, this integration is responsible for publishing the value for this point. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for availability status (values vary by equipment vendor). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for availability status (values vary by equipment vendor). |
 
 ---
 
@@ -719,7 +719,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | `pointType` | string | No | Values: `LeakDetect` |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for leak detection. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for leak detection. |
 
 ---
 
@@ -937,7 +937,7 @@ Rack-specific identifier fields added to all Rack metadata messages.
 | `pointType` | string | Yes | Values: `RackLeakDetect` |
 | `rackLocationName` | string | Yes | Human-readable rack name as defined by the BMS. |
 | `rackLocationId` | string | Yes | Stable unique identifier for the rack. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for leak detection. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for leak detection. |
 
 ---
 
@@ -951,7 +951,7 @@ Rack-specific identifier fields added to all Rack metadata messages.
 | `pointType` | string | Yes | Values: `RackLeakSensorFault` |
 | `rackLocationName` | string | Yes | Human-readable rack name as defined by the BMS. |
 | `rackLocationId` | string | Yes | Stable unique identifier for the rack. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for leak sensor fault status. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for leak sensor fault status. |
 
 ---
 
@@ -965,7 +965,7 @@ Rack-specific identifier fields added to all Rack metadata messages.
 | `pointType` | string | Yes | Values: `RackLiquidIsolationStatus` |
 | `rackLocationName` | string | Yes | Human-readable rack name as defined by the BMS. |
 | `rackLocationId` | string | Yes | Stable unique identifier for the rack. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for liquid isolation status. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for liquid isolation status. |
 
 ---
 
@@ -979,7 +979,7 @@ Rack-specific identifier fields added to all Rack metadata messages.
 | `pointType` | string | Yes | Values: `RackElectricalIsolationStatus` |
 | `rackLocationName` | string | Yes | Human-readable rack name as defined by the BMS. |
 | `rackLocationId` | string | Yes | Stable unique identifier for the rack. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for electrical isolation status. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for electrical isolation status. |
 
 ---
 
@@ -994,7 +994,7 @@ Rack-specific identifier fields added to all Rack metadata messages.
 | `rackLocationName` | string | Yes | Human-readable rack name as defined by the BMS. |
 | `rackLocationId` | string | Yes | Stable unique identifier for the rack. |
 | `integration` | string | Yes | Integration identifier responsible for publishing this value. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for tray leak detection. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for tray leak detection. |
 
 ---
 
@@ -1009,7 +1009,7 @@ Rack-specific identifier fields added to all Rack metadata messages.
 | `rackLocationName` | string | Yes | Human-readable rack name as defined by the BMS. |
 | `rackLocationId` | string | Yes | Stable unique identifier for the rack. |
 | `integration` | string | Yes | Integration identifier responsible for publishing this value. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for liquid isolation request. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for liquid isolation request. |
 
 ---
 
@@ -1024,7 +1024,7 @@ Rack-specific identifier fields added to all Rack metadata messages.
 | `rackLocationName` | string | Yes | Human-readable rack name as defined by the BMS. |
 | `rackLocationId` | string | Yes | Stable unique identifier for the rack. |
 | `integration` | string | Yes | Integration identifier responsible for publishing this value. |
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping for electrical isolation request. |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping for electrical isolation request. |
 
 ---
 
@@ -1038,7 +1038,7 @@ PowerMeter-specific identifier fields added to all PowerMeter metadata messages.
 | `pointType` | string | Yes | Values: `Voltage` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 | `engUnit` | string | Yes |  |
 
 ---
@@ -1053,7 +1053,7 @@ Dimensionless 0–1. engUnit not required.
 | `pointType` | string | Yes | Values: `PowerFactor` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 
 ---
 
@@ -1067,7 +1067,7 @@ PowerMeter-specific identifier fields added to all PowerMeter metadata messages.
 | `pointType` | string | Yes | Values: `Frequency` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 | `engUnit` | string | Yes |  |
 
 ---
@@ -1082,7 +1082,7 @@ PowerMeter-specific identifier fields added to all PowerMeter metadata messages.
 | `pointType` | string | Yes | Values: `ApparentPower` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 | `engUnit` | string | Yes |  |
 
 ---
@@ -1097,7 +1097,7 @@ PowerMeter-specific identifier fields added to all PowerMeter metadata messages.
 | `pointType` | string | Yes | Values: `ActivePower` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 | `engUnit` | string | Yes |  |
 
 ---
@@ -1112,7 +1112,7 @@ PowerMeter-specific identifier fields added to all PowerMeter metadata messages.
 | `pointType` | string | Yes | Values: `Current` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 | `engUnit` | string | Yes |  |
 
 ---
@@ -1127,7 +1127,7 @@ PowerMeter-specific identifier fields added to all PowerMeter metadata messages.
 | `pointType` | string | Yes | Values: `CurrentLimit` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 | `engUnit` | string | Yes |  |
 
 ---
@@ -1142,7 +1142,7 @@ PhaseCurrent additionally requires `phase` to identify which electrical phase. A
 | `pointType` | string | Yes | Values: `PhaseCurrent` |
 | `objectName` | string | Yes | Human-readable name of the electrical device. |
 | `objectId` | string | Yes | Stable unique identifier for the electrical device. |
-| `servesId` | array\&lt;string\> | Yes | List of objectIds of entities served by this power meter. |
+| `servesId` | array&lt;string&gt; | Yes | List of objectIds of entities served by this power meter. |
 | `engUnit` | string | Yes |  |
 | `phase` | string | Yes | Electrical phase identifier. Letter form (A/B/C) and numeric form (1/2/3) are both accepted to align with publisher conventions. Values: `A`, `B`, `C`, `1`, `2`, `3` |
 
@@ -1167,7 +1167,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1199,7 +1199,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -1219,7 +1219,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -1239,7 +1239,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -1262,7 +1262,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1297,7 +1297,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1329,7 +1329,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -1349,7 +1349,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -1369,7 +1369,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -1389,7 +1389,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -1412,7 +1412,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1444,7 +1444,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -1464,7 +1464,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -1484,7 +1484,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -1507,7 +1507,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1542,7 +1542,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1641,7 +1641,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1676,7 +1676,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1871,7 +1871,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1906,7 +1906,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1941,7 +1941,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -1976,7 +1976,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2011,7 +2011,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2046,7 +2046,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2081,7 +2081,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2116,7 +2116,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2151,7 +2151,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2186,7 +2186,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2221,7 +2221,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2256,7 +2256,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2288,7 +2288,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2308,7 +2308,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2328,7 +2328,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2348,7 +2348,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2371,7 +2371,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2406,7 +2406,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2441,7 +2441,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2476,7 +2476,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2511,7 +2511,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2546,7 +2546,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2578,7 +2578,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2598,7 +2598,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2618,7 +2618,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2641,7 +2641,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2673,7 +2673,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2693,7 +2693,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2713,7 +2713,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2736,7 +2736,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2771,7 +2771,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2803,7 +2803,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2826,7 +2826,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2858,7 +2858,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2878,7 +2878,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2898,7 +2898,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -2921,7 +2921,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2956,7 +2956,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -2988,7 +2988,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3008,7 +3008,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3028,7 +3028,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3048,7 +3048,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3071,7 +3071,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3103,7 +3103,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3123,7 +3123,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3143,7 +3143,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3166,7 +3166,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3198,7 +3198,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3221,7 +3221,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3253,7 +3253,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3273,7 +3273,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3293,7 +3293,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3316,7 +3316,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3351,7 +3351,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3383,7 +3383,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3403,7 +3403,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3423,7 +3423,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3443,7 +3443,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3466,7 +3466,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3498,7 +3498,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3518,7 +3518,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3538,7 +3538,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3561,7 +3561,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3593,7 +3593,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3616,7 +3616,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3648,7 +3648,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3668,7 +3668,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3688,7 +3688,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3711,7 +3711,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3746,7 +3746,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3778,7 +3778,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3798,7 +3798,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3818,7 +3818,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3838,7 +3838,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3861,7 +3861,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3893,7 +3893,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3913,7 +3913,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3933,7 +3933,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -3956,7 +3956,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -3988,7 +3988,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4011,7 +4011,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4043,7 +4043,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4063,7 +4063,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4083,7 +4083,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4106,7 +4106,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4141,7 +4141,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4173,7 +4173,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4193,7 +4193,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4213,7 +4213,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4233,7 +4233,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4256,7 +4256,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4288,7 +4288,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4308,7 +4308,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4328,7 +4328,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4351,7 +4351,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4383,7 +4383,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4406,7 +4406,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4438,7 +4438,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4458,7 +4458,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4478,7 +4478,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4501,7 +4501,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4536,7 +4536,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4568,7 +4568,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4588,7 +4588,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4608,7 +4608,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4628,7 +4628,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4651,7 +4651,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4683,7 +4683,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4703,7 +4703,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4723,7 +4723,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4746,7 +4746,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4778,7 +4778,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4801,7 +4801,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4833,7 +4833,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4853,7 +4853,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4873,7 +4873,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4896,7 +4896,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4931,7 +4931,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -4963,7 +4963,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -4983,7 +4983,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5003,7 +5003,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5023,7 +5023,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5046,7 +5046,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -5078,7 +5078,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5098,7 +5098,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5118,7 +5118,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5141,7 +5141,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -5173,7 +5173,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5196,7 +5196,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -5228,7 +5228,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5248,7 +5248,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5268,7 +5268,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5291,7 +5291,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -5326,7 +5326,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -5358,7 +5358,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5378,7 +5378,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5398,7 +5398,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5418,7 +5418,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5441,7 +5441,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -5473,7 +5473,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5493,7 +5493,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5513,7 +5513,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5536,7 +5536,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -5568,7 +5568,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5591,7 +5591,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -5623,7 +5623,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5643,7 +5643,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5663,7 +5663,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5686,7 +5686,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -5721,7 +5721,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -5753,7 +5753,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5773,7 +5773,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5793,7 +5793,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5813,7 +5813,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5836,7 +5836,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -5868,7 +5868,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5888,7 +5888,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5908,7 +5908,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5931,7 +5931,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -5963,7 +5963,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -5986,7 +5986,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -6018,7 +6018,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -6038,7 +6038,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -6058,7 +6058,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -6081,7 +6081,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -6116,7 +6116,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -6148,7 +6148,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -6168,7 +6168,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -6188,7 +6188,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -6208,7 +6208,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -6231,7 +6231,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -6263,7 +6263,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -6283,7 +6283,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -6303,7 +6303,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -6326,7 +6326,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -6361,7 +6361,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -6393,7 +6393,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -6416,7 +6416,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -6452,7 +6452,7 @@ Field fragment for a vendor-specific or unmapped GenericPoint. `processArea` is 
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | No | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | No | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---
 
@@ -6479,7 +6479,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -6515,6 +6515,6 @@ Field fragment for a vendor-specific or unmapped GenericPoint. `processArea` is 
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | No | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | No | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 ---

--- a/docs/schema-bms-sensor-metadata.mdx
+++ b/docs/schema-bms-sensor-metadata.mdx
@@ -44,7 +44,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -90,7 +90,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -120,7 +120,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -150,7 +150,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -183,7 +183,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -229,7 +229,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -259,7 +259,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -289,7 +289,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -319,7 +319,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -352,7 +352,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -401,7 +401,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -450,7 +450,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -501,7 +501,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 

--- a/docs/schema-bms-shunt-metadata.mdx
+++ b/docs/schema-bms-shunt-metadata.mdx
@@ -44,7 +44,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -93,7 +93,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -144,7 +144,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 

--- a/docs/schema-bms-tank-metadata.mdx
+++ b/docs/schema-bms-tank-metadata.mdx
@@ -45,7 +45,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -91,7 +91,7 @@ Measurement fields for LiquidDifferentialPressure. Typical engUnit: kPa. The ide
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -121,7 +121,7 @@ Measurement fields for LiquidFlow. Typical engUnit: LPM. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -151,7 +151,7 @@ Measurement fields for LiquidPressure. Typical engUnit: kPa. The identifier (nam
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -184,7 +184,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -233,7 +233,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -279,7 +279,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -309,7 +309,7 @@ Measurement fields for PumpSpeed. Typical engUnit: RPM. The identifier (named-ob
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -339,7 +339,7 @@ Measurement fields for FanSpeed. Typical engUnit: RPM. The identifier (named-obj
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -369,7 +369,7 @@ Measurement fields for DamperPosition. Typical engUnit: %. The identifier (named
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -402,7 +402,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -448,7 +448,7 @@ Measurement fields for AirDifferentialPressure. Typical engUnit: Pa. The identif
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -478,7 +478,7 @@ Measurement fields for AirRelativeHumidity. Typical engUnit: %RH. The identifier
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -508,7 +508,7 @@ Measurement fields for AirFlow. Typical engUnit: CFM. The identifier (named-obje
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -538,7 +538,7 @@ Measurement fields for AirPressure. Typical engUnit: Pa. The identifier (named-o
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -571,7 +571,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -622,7 +622,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 

--- a/docs/schema-bms-ups-metadata.mdx
+++ b/docs/schema-bms-ups-metadata.mdx
@@ -44,7 +44,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -93,7 +93,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -144,7 +144,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 

--- a/docs/schema-bms-valve-metadata.mdx
+++ b/docs/schema-bms-valve-metadata.mdx
@@ -41,7 +41,7 @@ Measurement fields for ValvePosition. Typical engUnit: %. The identifier (named-
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `stateText` | array\&lt;map\&lt;string, any\>\> | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
+| `stateText` | array&lt;map&lt;string, any&gt;&gt; | Yes | State label mapping. Each entry maps a numeric state value to its human-readable label (e.g., `[{value: 0, text: "Off"}, {value: 1, text: "On"}]`). |
 
 <Accordion title="Example payload">
 
@@ -74,7 +74,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 
@@ -125,7 +125,7 @@ the parent `oneOf`.
 |------|------|----------|-------------|
 | `objectName` | string | Yes | Human-readable equipment name. |
 | `objectId` | string | Yes | Stable unique identifier for the equipment. |
-| `servesId` | array\&lt;string\> | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
 
 ### Associate Mode
 

--- a/docs/schema-nico-schemas.mdx
+++ b/docs/schema-nico-schemas.mdx
@@ -13,7 +13,7 @@ Dpu was discovered by a site-explorer and is being configuring via redfish.
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | `dpu_states` | [DpuDiscoveringStates](schema-nico-schemas.mdx#dpudiscoveringstates) | Yes |  |
-| `dpu_states.states` | map\&lt;string, [DpuDiscoveringState](schema-nico-schemas.mdx#dpudiscoveringstate)\> | Yes |  |
+| `dpu_states.states` | map&lt;string, [DpuDiscoveringState](schema-nico-schemas.mdx#dpudiscoveringstate)&gt; | Yes |  |
 | `state` | string | Yes | Values: `dpudiscoveringstate` |
 
 ### dpuinit
@@ -23,7 +23,7 @@ DPU is not yet ready.
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | `dpu_states` | [DpuInitStates](schema-nico-schemas.mdx#dpuinitstates) | Yes |  |
-| `dpu_states.states` | map\&lt;string, [DpuInitState](schema-nico-schemas.mdx#dpuinitstate)\> | Yes |  |
+| `dpu_states.states` | map&lt;string, [DpuInitState](schema-nico-schemas.mdx#dpuinitstate)&gt; | Yes |  |
 | `state` | string | Yes | Values: `dpuinit` |
 
 ### hostinit
@@ -107,7 +107,7 @@ State used to indicate that DPU reprovisioning is going on.
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | `dpu_states` | [DpuReprovisionStates](schema-nico-schemas.mdx#dpureprovisionstates) | Yes |  |
-| `dpu_states.states` | map\&lt;string, [ReprovisionState](schema-nico-schemas.mdx#reprovisionstate)\> | Yes |  |
+| `dpu_states.states` | map&lt;string, [ReprovisionState](schema-nico-schemas.mdx#reprovisionstate)&gt; | Yes |  |
 | `state` | string | Yes | Values: `dpureprovision` |
 
 ### hostreprovision
@@ -410,7 +410,7 @@ A context for passing information between states thoughout the BOM validation pr
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `states` | map\&lt;string, [DpuDiscoveringState](schema-nico-schemas.mdx#dpudiscoveringstate)\> | Yes |  |
+| `states` | map&lt;string, [DpuDiscoveringState](schema-nico-schemas.mdx#dpudiscoveringstate)&gt; | Yes |  |
 
 ---
 
@@ -466,7 +466,7 @@ A context for passing information between states thoughout the BOM validation pr
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `states` | map\&lt;string, [DpuInitState](schema-nico-schemas.mdx#dpuinitstate)\> | Yes |  |
+| `states` | map&lt;string, [DpuInitState](schema-nico-schemas.mdx#dpuinitstate)&gt; | Yes |  |
 
 ---
 
@@ -474,7 +474,7 @@ A context for passing information between states thoughout the BOM validation pr
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `states` | map\&lt;string, [ReprovisionState](schema-nico-schemas.mdx#reprovisionstate)\> | Yes |  |
+| `states` | map&lt;string, [ReprovisionState](schema-nico-schemas.mdx#reprovisionstate)&gt; | Yes |  |
 
 ---
 
@@ -837,7 +837,7 @@ Possible Instance state-machine implementation, for when the machine host is ass
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | `dpu_states` | [DpuReprovisionStates](schema-nico-schemas.mdx#dpureprovisionstates) | Yes |  |
-| `dpu_states.states` | map\&lt;string, [ReprovisionState](schema-nico-schemas.mdx#reprovisionstate)\> | Yes |  |
+| `dpu_states.states` | map&lt;string, [ReprovisionState](schema-nico-schemas.mdx#reprovisionstate)&gt; | Yes |  |
 | `state` | string | Yes | Values: `dpureprovision` |
 
 ### failed

--- a/docs/schema-power-management-schemas.mdx
+++ b/docs/schema-power-management-schemas.mdx
@@ -48,7 +48,7 @@ Power limit constraint.
 List of feed identifiers this target applies to (e.g., ["main-a"]).
 If omitted or empty, the target applies to all feeds.
 
-**Type:** array\&lt;string\>
+**Type:** array&lt;string&gt;
 
 List of feed identifiers this target applies to (e.g., ["main-a"]).
 If omitted or empty, the target applies to all feeds.
@@ -143,7 +143,7 @@ Current power state for a single feed.
 | `metadata.default_constraint` | object | Yes | Power measurement with value and unit. |
 | `metadata.default_constraint.value` | number (double) | Yes | Power value (must be >= 0). |
 | `metadata.default_constraint.unit` | string | Yes | Unit of measurement. Values: `watt`, `kilowatt`, `megawatt` |
-| `targets` | array\<[FeedTarget](schema-power-management-schemas.mdx#feedtarget)\> | Yes | All load targets for this feed — active and scheduled. Empty array if no targets exist. |
+| `targets` | array&lt;[FeedTarget](schema-power-management-schemas.mdx#feedtarget)&gt; | Yes | All load targets for this feed — active and scheduled. Empty array if no targets exist. |
 | `calculated_load` | object | Yes | Power measurement with value and unit. |
 | `calculated_load.value` | number (double) | Yes | Power value (must be >= 0). |
 | `calculated_load.unit` | string | Yes | Unit of measurement. Values: `watt`, `kilowatt`, `megawatt` |
@@ -185,7 +185,7 @@ Payload for grid.loadtarget.set.v1.
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `targets` | array\&lt;object\> | Yes | List of load target requests. |
+| `targets` | array&lt;object&gt; | Yes | List of load target requests. |
 
 ---
 
@@ -196,7 +196,7 @@ Payload for grid.powerstate.status.v1.
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | `snapshot_time` | string (date-time) | Yes | ISO 8601 UTC timestamp of this snapshot. |
-| `feeds` | map\&lt;string, [FeedState](schema-power-management-schemas.mdx#feedstate)\> | Yes | Map of feed_tag to power state. |
+| `feeds` | map&lt;string, [FeedState](schema-power-management-schemas.mdx#feedstate)&gt; | Yes | Map of feed_tag to power state. |
 
 ---
 
@@ -221,8 +221,8 @@ Payload for grid.powerbreach.alert.v1.
 | `measured_load` | object | Yes | Power measurement with value and unit. |
 | `measured_load.value` | number (double) | Yes | Power value (must be >= 0). |
 | `measured_load.unit` | string | Yes | Unit of measurement. Values: `watt`, `kilowatt`, `megawatt` |
-| `shed_hints` | array\<[ShedHint](schema-power-management-schemas.mdx#shedhint)\> | No | Ordered list of load shedding recommendations. Present when status is active or escalated. Absent when resolved. |
-| `infrastructure_actions` | array\&lt;string\> | Yes | Ordered list of escalating infrastructure-level actions. Empty array when status is resolved. Ordered from least to most disruptive. |
+| `shed_hints` | array&lt;[ShedHint](schema-power-management-schemas.mdx#shedhint)&gt; | No | Ordered list of load shedding recommendations. Present when status is active or escalated. Absent when resolved. |
+| `infrastructure_actions` | array&lt;string&gt; | Yes | Ordered list of escalating infrastructure-level actions. Empty array when status is resolved. Ordered from least to most disruptive. |
 
 ---
 
@@ -237,7 +237,7 @@ Payload for grid.powerbreach.enforcement.v1.
 | `action` | string | Yes | What phase of enforcement this represents. Values: `applied`, `reverted` |
 | `code` | string | Yes | Overall enforcement outcome. Values: `success`, `partial`, `error` |
 | `diag_msg` | string | No | Human-readable diagnostic message. |
-| `results` | array\<[EnforcementResult](schema-power-management-schemas.mdx#enforcementresult)\> | Yes | Per-resource enforcement outcome. |
+| `results` | array&lt;[EnforcementResult](schema-power-management-schemas.mdx#enforcementresult)&gt; | Yes | Per-resource enforcement outcome. |
 | `timestamp` | string (date-time) | Yes | ISO 8601 UTC timestamp when enforcement completed. |
 
 ---

--- a/docs/schema-spiffe-exchange-messages.mdx
+++ b/docs/schema-spiffe-exchange-messages.mdx
@@ -10,7 +10,7 @@
 |------|------|----------|-------------|
 | `kty` | string | Yes | Key type (e.g. RSA, EC, OKP). Values: `RSA`, `EC`, `OKP` |
 | `use` | string | No | Public key use (sig, enc, or omitted). Values: `sig`, `enc` |
-| `key_ops` | array\&lt;string\> | No | Key operations (e.g. verify, encrypt). |
+| `key_ops` | array&lt;string&gt; | No | Key operations (e.g. verify, encrypt). |
 | `alg` | string | No | Algorithm (e.g. ES256, RS256, EdDSA). |
 | `kid` | string | No | Key ID; should match the topic kid when present. |
 | `n` | string | No | RSA modulus (Base64url). |

--- a/docs/schema-spiffe-exchange-publishpubkeyset.mdx
+++ b/docs/schema-spiffe-exchange-publishpubkeyset.mdx
@@ -27,7 +27,7 @@ spiffe-exchange/v1/pub-keysets/tenant/{tenant_domain}/kid/{kid}
 |------|------|----------|-------------|
 | `kty` | string | Yes | Key type (e.g. RSA, EC, OKP). Values: `RSA`, `EC`, `OKP` |
 | `use` | string | No | Public key use (sig, enc, or omitted). Values: `sig`, `enc` |
-| `key_ops` | array\&lt;string\> | No | Key operations (e.g. verify, encrypt). |
+| `key_ops` | array&lt;string&gt; | No | Key operations (e.g. verify, encrypt). |
 | `alg` | string | No | Algorithm (e.g. ES256, RS256, EdDSA). |
 | `kid` | string | No | Key ID; should match the topic kid when present. |
 | `n` | string | No | RSA modulus (Base64url). |

--- a/docs/schema-spiffe-exchange-schemas.mdx
+++ b/docs/schema-spiffe-exchange-schemas.mdx
@@ -8,7 +8,7 @@ Single JSON Web Key per RFC 7517. Only public key parameters are included on thi
 |------|------|----------|-------------|
 | `kty` | string | Yes | Key type (e.g. RSA, EC, OKP). Values: `RSA`, `EC`, `OKP` |
 | `use` | string | No | Public key use (sig, enc, or omitted). Values: `sig`, `enc` |
-| `key_ops` | array\&lt;string\> | No | Key operations (e.g. verify, encrypt). |
+| `key_ops` | array&lt;string&gt; | No | Key operations (e.g. verify, encrypt). |
 | `alg` | string | No | Algorithm (e.g. ES256, RS256, EdDSA). |
 | `kid` | string | No | Key ID; should match the topic kid when present. |
 | `n` | string | No | RSA modulus (Base64url). |

--- a/docs/schema-spiffe-exchange-subscribepubkeyset.mdx
+++ b/docs/schema-spiffe-exchange-subscribepubkeyset.mdx
@@ -27,7 +27,7 @@ spiffe-exchange/v1/pub-keysets/tenant/{tenant_domain}/kid/{kid}
 |------|------|----------|-------------|
 | `kty` | string | Yes | Key type (e.g. RSA, EC, OKP). Values: `RSA`, `EC`, `OKP` |
 | `use` | string | No | Public key use (sig, enc, or omitted). Values: `sig`, `enc` |
-| `key_ops` | array\&lt;string\> | No | Key operations (e.g. verify, encrypt). |
+| `key_ops` | array&lt;string&gt; | No | Key operations (e.g. verify, encrypt). |
 | `alg` | string | No | Algorithm (e.g. ES256, RS256, EdDSA). |
 | `kid` | string | No | Key ID; should match the topic kid when present. |
 | `n` | string | No | RSA modulus (Base64url). |

--- a/scripts/generate_asyncapi_docs.py
+++ b/scripts/generate_asyncapi_docs.py
@@ -488,11 +488,11 @@ def _type_str(schema: dict, spec: dict, schema_doc: str | None = None) -> str:
     if t == "array":
         items = schema.get("items", {})
         inner = _type_str(items, spec, schema_doc=schema_doc)
-        return f"array\\<{inner}\\>"
+        return f"array&lt;{inner}&gt;"
     if t == "object" and "additionalProperties" in schema:
         ap = schema["additionalProperties"]
         inner = _type_str(ap, spec, schema_doc=schema_doc) if isinstance(ap, dict) else "any"
-        return f"map\\<string, {inner}\\>"
+        return f"map&lt;string, {inner}&gt;"
     if t == "string" and schema.get("format"):
         return f"string ({schema['format']})"
     if t == "number" and schema.get("format"):


### PR DESCRIPTION
## Description

Script was outputting an escaped `&lt;` entity instead of the actual entity. This fixes that, outputs the ending `>` as `&gt;`, and regenerates all the affected files.

## Validation

```bash
fern docs md check
fern check
rumdl check docs
fern docs dev    # searched schema overview pages for "&" and found none
```

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/dsx-exchange/blob/main/CONTRIBUTING.md).
- [x] Documentation updated, if needed.
- [x] Tests or validation added/updated, if needed.
- [x] License headers are present on applicable source files.
- [x] Third-party license inventory updated, if dependencies changed.
- [x] Security-sensitive changes were reviewed privately before public disclosure.
- [x] My commits are signed off (`git commit -s`) per the DCO.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved schema documentation formatting to ensure type annotations in BMS, power management, and SPIFFE schema tables display correctly. Fixed rendering issues across multiple equipment and sensor metadata schemas, enhancing readability of field type information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->