### PR TITLE
build(local): run e2e through skaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ If you already have a DSX Exchange broker and need to build or test an MQTT
 integration application, start with the
 [Integrator Quickstart](https://docs.nvidia.com/dsx-exchange/integrator-quickstart).
 
-For local end-to-end validation, create the Kind environment and deploy NATS:
+For local end-to-end validation, create the Kind environment and deploy the
+Skaffold-managed local stack:
 
 ```bash
 make -C local install-e2e-prereqs
-make -C local setup-infra
-make -C local deploy-nats
+make -C local skaffold-run
 make -C local validate-nats
 make test-e2e
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,8 +10,7 @@ To evaluate DSX Exchange locally without Vault, VSO, or production certificate i
 
 ```bash
 make -C local install-e2e-prereqs
-make -C local setup-infra      # Kind clusters + required Skaffold-managed infra
-make -C local deploy-nats       # Build auth-callout and deploy NATS to all clusters
+make -C local skaffold-run      # Kind clusters + Skaffold-managed infra and NATS
 make -C local validate-nats     # Verify connectivity
 ```
 
@@ -89,7 +88,7 @@ helm install dsx ./deploy/nats-event-bus \
 
 For a working CSC reference, see `local/nats/k8s/local-dev-values.yaml` and
 `local/nats/k8s/csc/values.yaml`. Those are the values applied by
-`make -C local deploy-nats`.
+`make -C local skaffold-run`.
 
 CSC values configure the cluster type, list of CPC IDs that will connect, and auth permissions:
 
@@ -140,7 +139,7 @@ helm install dsx ./deploy/nats-event-bus \
 
 For a working CPC reference, see `local/nats/k8s/local-dev-values.yaml`,
 `local/nats/k8s/cpc/values.yaml`, and `local/nats/k8s/cpc/cpc-1.yaml`. Those are
-the values applied by `make -C local deploy-nats`.
+the values applied by `make -C local skaffold-run`.
 
 CPC values set the cluster type, cluster ID, CSC endpoint, and cross-layer routing:
 

--- a/docs/integrator-quickstart.md
+++ b/docs/integrator-quickstart.md
@@ -53,8 +53,7 @@ macOS, install and start `docker-mac-net-connect` from the local quick start so
 the host can reach the MetalLB IPs.
 
 ```bash
-cd local
-make install-e2e-prereqs setup-infra deploy-nats
+make -C local install-e2e-prereqs skaffold-run
 ```
 
 Use the local CSC broker endpoint:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -20,7 +20,7 @@ operator-driven benchmark runs. These tests report the observed behavior of the
 current deployment; they do not define product targets.
 
 **Prerequisite:** Performance and benchmark targets require MetalLB or an
-equivalent LoadBalancer installed by `make -C local setup-infra`. On macOS, start
+equivalent LoadBalancer installed by `make -C local skaffold-run`. On macOS, start
 `docker-mac-net-connect` so the host can reach the MetalLB IPs. Linux hosts
 normally reach the Docker bridge IPs directly.
 

--- a/local/Makefile
+++ b/local/Makefile
@@ -27,6 +27,7 @@ install-e2e-prereqs: ## Install local Kind e2e CLI prerequisites into E2E_PREREQ
 
 e2e-kind: install-e2e-prereqs ## Set up local Kind clusters, deploy with Skaffold, and run the e2e suite
 	$(MAKE) skaffold-run
+	$(MAKE) validate-nats
 	$(MAKE) test-functional
 	$(MAKE) test-performance
 
@@ -93,13 +94,13 @@ check-e2e-env: ## Check local Kind/NATS prerequisites for e2e tests
 	@echo "Checking local e2e prerequisites..."
 	@for cluster in csc cpc-1 cpc-2; do \
 		kind get clusters | grep -q "^$${cluster}$$" || { \
-			echo "Missing Kind cluster: $${cluster}. Run 'make -C local setup-infra deploy-nats' first."; \
+			echo "Missing Kind cluster: $${cluster}. Run 'make -C local skaffold-run' first."; \
 			exit 1; \
 		}; \
 	done
 	@for context in kind-csc kind-cpc-1 kind-cpc-2; do \
 		kubectl get namespace event-bus --context "$${context}" >/dev/null 2>&1 || { \
-			echo "Missing event-bus namespace in $${context}. Run 'make -C local deploy-nats' first."; \
+			echo "Missing event-bus namespace in $${context}. Run 'make -C local skaffold-run' first."; \
 			exit 1; \
 		}; \
 	done

--- a/local/README.md
+++ b/local/README.md
@@ -39,30 +39,31 @@ You may need to restart the service if it stops working.
 sudo brew services restart chipmk/tap/docker-mac-net-connect
 ```
 
-### Setup Infrastructure
+### Setup Local Stack
 
 ```bash
 # Install local e2e tools, including the pinned Skaffold version
 make install-e2e-prereqs
 
-# Create all three Kind clusters and deploy required infrastructure with Skaffold
-make setup-infra
+# Create all three Kind clusters and deploy required infrastructure and NATS with Skaffold
+make skaffold-run
 
-# Verify infrastructure is ready
+# Verify infrastructure and NATS are ready
 make verify-infra
+make validate-nats
 ```
 
-### Deploy Event Bus
+### Deploy Event Bus Only
 
 ```bash
-# Build auth-callout and deploy NATS to all layers with Skaffold
+# Rebuild auth-callout and redeploy NATS after infrastructure already exists
 make deploy-nats
 ```
 
 ### Run Tests
 
-Performance and benchmark targets require MetalLB, installed by
-`make setup-infra`, so local clients connect through the Envoy Gateway
+Performance and benchmark targets require MetalLB, installed by the
+Skaffold-managed local stack, so local clients connect through the Envoy Gateway
 LoadBalancer IPs. On macOS, keep `docker-mac-net-connect` running so the host can
 reach those IPs. Linux hosts normally reach the Docker bridge IPs directly.
 

--- a/local/infra/README.md
+++ b/local/infra/README.md
@@ -27,11 +27,12 @@ from the host. Linux hosts normally reach the Docker bridge IPs directly. See
 # Install local e2e tools, including the pinned Skaffold version
 make install-e2e-prereqs
 
-# Setup required local infrastructure with Skaffold
-make setup-infra
+# Setup the complete local stack with Skaffold
+make skaffold-run
 
 # Verify everything is running
 make verify-infra
+make validate-nats
 
 # Verify the host can reach the CSC Keycloak HTTPRoute through Envoy Gateway
 curl http://172.18.200.1/realms/event-bus/.well-known/openid-configuration
@@ -532,9 +533,9 @@ kind delete cluster --name cpc-2
 
 ## Next Steps
 
-After infrastructure is ready:
+After the local stack is ready:
 
-1. Deploy event bus:
+1. Reconcile the event bus after NATS or auth-callout changes:
 
    ```bash
    make deploy-nats

--- a/local/nats/README.md
+++ b/local/nats/README.md
@@ -11,12 +11,20 @@ For architecture and chart configuration details, see
 ### Prerequisites
 
 - Kind clusters created (CSC, CPC-1, CPC-2)
-- Local infrastructure deployed with `make -C local setup-infra`
+- Local infrastructure deployed with `make -C local skaffold-run` or
+  `make -C local setup-infra`
 - Helm 4.0+
 - kubectl configured with cluster contexts
 - Skaffold installed by `make -C local install-e2e-prereqs`
 
-### Deploy to All Layers
+### Deploy Complete Local Stack
+
+```bash
+# From the repository root
+make -C local skaffold-run
+```
+
+### Deploy NATS After Infrastructure Exists
 
 ```bash
 # From the repository root

--- a/local/nats/validate.sh
+++ b/local/nats/validate.sh
@@ -32,6 +32,22 @@ get_extra_accounts() {
   done | sort -u
 }
 
+leaf_federation_ready() {
+  local leaf_json=$1
+  local leaf_count
+  local account_name
+
+  leaf_count=$(echo "${leaf_json}" | jq -r '.leafs | length' 2>/dev/null || echo "0")
+  if [ "${leaf_count}" = "null" ] || [ "${leaf_count}" -eq 0 ]; then
+    return 1
+  fi
+
+  for account_name in $(get_extra_accounts); do
+    echo "${leaf_json}" | jq -e --arg account "${account_name}" \
+      '.leafs[]? | select(.account == $account)' >/dev/null || return 1
+  done
+}
+
 echo "Validating NATS deployment on ${cluster}..."
 echo ""
 
@@ -87,8 +103,20 @@ echo ""
 
 # Check Leaf Node connections
 echo "Checking Leaf Node federation..."
-leafz=$(kubectl exec -n ${namespace} nats-0 --context "${context}" -c nats -- \
-  wget -qO- http://localhost:8222/leafz 2>/dev/null)
+for i in {1..60}; do
+  leafz=$(kubectl exec -n ${namespace} nats-0 --context "${context}" -c nats -- \
+    wget -qO- http://localhost:8222/leafz 2>/dev/null || true)
+
+  if leaf_federation_ready "${leafz}"; then
+    break
+  fi
+
+  if [ "${i}" -eq 60 ]; then
+    break
+  fi
+
+  sleep 1
+done
 
 leaf_count=$(echo "${leafz}" | jq -r '.leafs | length' 2>/dev/null || echo "0")
 echo "Leaf node connections: ${leaf_count}"


### PR DESCRIPTION
## Summary
- Make `local/e2e-kind` deploy through `skaffold-run` before running validation, functional tests, and performance tests.
- Update local docs and quick starts to use the complete Skaffold-managed local stack.
- Make NATS validation wait briefly for leaf federation readiness before reporting failure.

## Behavior changes
- `make -C local e2e-kind` now runs `make -C local validate-nats` before Go e2e tests.
- `make -C local skaffold-run` is now the documented complete local stack path; `make -C local deploy-nats` remains the NATS-only reconciliation path after infrastructure exists.
- No address/topology change: local e2e still uses MetalLB and Envoy Gateway IPs (`172.18.200.1`, `172.18.201.1`, `172.18.202.1`). No NodePort or port-forward path is introduced.

## Validation
- `make -C local clean-e2e`
- `make -C local E2E_PREREQS_BIN=/private/tmp/dsx-e2e-bin SKAFFOLD=/private/tmp/dsx-e2e-bin/skaffold e2e-kind`
- `git diff --check`
- `bash -n local/nats/validate.sh`
- `./tools/check-docs-mdx`
- `make check-license-headers`
- `make test-helm`

`fern check` was not available in the local shell (`fern: command not found`). No Fern workflow status was attached to this stacked PR; the local MDX safety check passed.