### PR TITLE
fix(docs): allow Integrations to write to BMS GenericPoint, available and status

### DIFF
--- a/docs/schema-bms-ahu-integration-value.mdx
+++ b/docs/schema-bms-ahu-integration-value.mdx
@@ -1,30 +1,30 @@
-# System Integration — Value
+# AHU Integration — Value
 
-Publish integration System values to topics derived from BMS metadata.
+Publish integration values for AHU control points.
 
 **Direction:** Publish (send)
 
 ## Channel
 
 ```text
-BMS/v1/{integration}/Value/System/{pointType}/{tagPath}
+BMS/v1/{integration}/Value/AHU/{pointType}/{tagPath}
 ```
 
-Values published by integrations for System points (Integration heartbeats, Status, Available, and GenericPoint).
-Subscribe to `BMS/v1/PUB/Metadata/System/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+Values published by integrations for AHU control points.
+Subscribe to `BMS/v1/PUB/Metadata/AHU/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
 That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
-- All integration System values: `BMS/v1/+/Value/System/#`
+- All integration AHU values: `BMS/v1/+/Value/AHU/#`
 
 ### Parameters
 
 | Parameter | Description |
 |-----------|-------------|
 | `integration` | Integration identifier. |
-| `pointType` | Integration-published System point type. Values: `HeartbeatTimestampIntegration`, `HeartbeatEchoIntegration`, `Status`, `Available`, `GenericPoint` |
-| `tagPath` | Vendor-defined hierarchical tag path. |
+| `pointType` | Integration-published AHU point type. Values: `GenericPoint` |
+| `tagPath` | Must match the tagPath from the corresponding BMS metadata exactly. |
 
 ## Message: Point Value
 

--- a/docs/schema-bms-ats-integration-value.mdx
+++ b/docs/schema-bms-ats-integration-value.mdx
@@ -1,30 +1,30 @@
-# System Integration — Value
+# ATS Integration — Value
 
-Publish integration System values to topics derived from BMS metadata.
+Publish integration values for ATS control points.
 
 **Direction:** Publish (send)
 
 ## Channel
 
 ```text
-BMS/v1/{integration}/Value/System/{pointType}/{tagPath}
+BMS/v1/{integration}/Value/ATS/{pointType}/{tagPath}
 ```
 
-Values published by integrations for System points (Integration heartbeats, Status, Available, and GenericPoint).
-Subscribe to `BMS/v1/PUB/Metadata/System/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+Values published by integrations for ATS control points.
+Subscribe to `BMS/v1/PUB/Metadata/ATS/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
 That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
-- All integration System values: `BMS/v1/+/Value/System/#`
+- All integration ATS values: `BMS/v1/+/Value/ATS/#`
 
 ### Parameters
 
 | Parameter | Description |
 |-----------|-------------|
 | `integration` | Integration identifier. |
-| `pointType` | Integration-published System point type. Values: `HeartbeatTimestampIntegration`, `HeartbeatEchoIntegration`, `Status`, `Available`, `GenericPoint` |
-| `tagPath` | Vendor-defined hierarchical tag path. |
+| `pointType` | Integration-published ATS point type. Values: `GenericPoint` |
+| `tagPath` | Must match the tagPath from the corresponding BMS metadata exactly. |
 
 ## Message: Point Value
 

--- a/docs/schema-bms-bess-integration-value.mdx
+++ b/docs/schema-bms-bess-integration-value.mdx
@@ -1,30 +1,30 @@
-# System Integration — Value
+# BESS Integration — Value
 
-Publish integration System values to topics derived from BMS metadata.
+Publish integration values for BESS control points.
 
 **Direction:** Publish (send)
 
 ## Channel
 
 ```text
-BMS/v1/{integration}/Value/System/{pointType}/{tagPath}
+BMS/v1/{integration}/Value/BESS/{pointType}/{tagPath}
 ```
 
-Values published by integrations for System points (Integration heartbeats, Status, Available, and GenericPoint).
-Subscribe to `BMS/v1/PUB/Metadata/System/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+Values published by integrations for BESS control points.
+Subscribe to `BMS/v1/PUB/Metadata/BESS/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
 That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
-- All integration System values: `BMS/v1/+/Value/System/#`
+- All integration BESS values: `BMS/v1/+/Value/BESS/#`
 
 ### Parameters
 
 | Parameter | Description |
 |-----------|-------------|
 | `integration` | Integration identifier. |
-| `pointType` | Integration-published System point type. Values: `HeartbeatTimestampIntegration`, `HeartbeatEchoIntegration`, `Status`, `Available`, `GenericPoint` |
-| `tagPath` | Vendor-defined hierarchical tag path. |
+| `pointType` | Integration-published BESS point type. Values: `GenericPoint` |
+| `tagPath` | Must match the tagPath from the corresponding BMS metadata exactly. |
 
 ## Message: Point Value
 

--- a/docs/schema-bms-breaker-integration-value.mdx
+++ b/docs/schema-bms-breaker-integration-value.mdx
@@ -1,30 +1,30 @@
-# System Integration — Value
+# Breaker Integration — Value
 
-Publish integration System values to topics derived from BMS metadata.
+Publish integration values for Breaker control points.
 
 **Direction:** Publish (send)
 
 ## Channel
 
 ```text
-BMS/v1/{integration}/Value/System/{pointType}/{tagPath}
+BMS/v1/{integration}/Value/Breaker/{pointType}/{tagPath}
 ```
 
-Values published by integrations for System points (Integration heartbeats, Status, Available, and GenericPoint).
-Subscribe to `BMS/v1/PUB/Metadata/System/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+Values published by integrations for Breaker control points.
+Subscribe to `BMS/v1/PUB/Metadata/Breaker/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
 That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
-- All integration System values: `BMS/v1/+/Value/System/#`
+- All integration Breaker values: `BMS/v1/+/Value/Breaker/#`
 
 ### Parameters
 
 | Parameter | Description |
 |-----------|-------------|
 | `integration` | Integration identifier. |
-| `pointType` | Integration-published System point type. Values: `HeartbeatTimestampIntegration`, `HeartbeatEchoIntegration`, `Status`, `Available`, `GenericPoint` |
-| `tagPath` | Vendor-defined hierarchical tag path. |
+| `pointType` | Integration-published Breaker point type. Values: `GenericPoint` |
+| `tagPath` | Must match the tagPath from the corresponding BMS metadata exactly. |
 
 ## Message: Point Value
 

--- a/docs/schema-bms-cdu-integration-value.mdx
+++ b/docs/schema-bms-cdu-integration-value.mdx
@@ -11,7 +11,8 @@ BMS/v1/{integration}/Value/CDU/{pointType}/{tagPath}
 ```
 
 Values published by integrations for CDU control points.
-Subscribe to `cduMetadata` first and read `integration` for the exact topic.
+Subscribe to `BMS/v1/PUB/Metadata/CDU/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
@@ -22,7 +23,7 @@ Subscribe to `cduMetadata` first and read `integration` for the exact topic.
 | Parameter | Description |
 |-----------|-------------|
 | `integration` | Integration identifier. |
-| `pointType` | Integration-published CDU point type. Values: `LiquidTemperatureSpRequest` |
+| `pointType` | Integration-published CDU point type. Values: `LiquidTemperatureSpRequest`, `GenericPoint` |
 | `tagPath` | Must match the tagPath from the corresponding BMS metadata exactly. |
 
 ## Message: Point Value

--- a/docs/schema-bms-chiller-integration-value.mdx
+++ b/docs/schema-bms-chiller-integration-value.mdx
@@ -1,30 +1,30 @@
-# System Integration — Value
+# Chiller Integration — Value
 
-Publish integration System values to topics derived from BMS metadata.
+Publish integration values for Chiller control points.
 
 **Direction:** Publish (send)
 
 ## Channel
 
 ```text
-BMS/v1/{integration}/Value/System/{pointType}/{tagPath}
+BMS/v1/{integration}/Value/Chiller/{pointType}/{tagPath}
 ```
 
-Values published by integrations for System points (Integration heartbeats, Status, Available, and GenericPoint).
-Subscribe to `BMS/v1/PUB/Metadata/System/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+Values published by integrations for Chiller control points.
+Subscribe to `BMS/v1/PUB/Metadata/Chiller/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
 That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
-- All integration System values: `BMS/v1/+/Value/System/#`
+- All integration Chiller values: `BMS/v1/+/Value/Chiller/#`
 
 ### Parameters
 
 | Parameter | Description |
 |-----------|-------------|
 | `integration` | Integration identifier. |
-| `pointType` | Integration-published System point type. Values: `HeartbeatTimestampIntegration`, `HeartbeatEchoIntegration`, `Status`, `Available`, `GenericPoint` |
-| `tagPath` | Vendor-defined hierarchical tag path. |
+| `pointType` | Integration-published Chiller point type. Values: `GenericPoint` |
+| `tagPath` | Must match the tagPath from the corresponding BMS metadata exactly. |
 
 ## Message: Point Value
 

--- a/docs/schema-bms-coolingtower-integration-value.mdx
+++ b/docs/schema-bms-coolingtower-integration-value.mdx
@@ -1,30 +1,30 @@
-# System Integration — Value
+# Cooling Tower Integration — Value
 
-Publish integration System values to topics derived from BMS metadata.
+Publish integration values for CoolingTower control points.
 
 **Direction:** Publish (send)
 
 ## Channel
 
 ```text
-BMS/v1/{integration}/Value/System/{pointType}/{tagPath}
+BMS/v1/{integration}/Value/CoolingTower/{pointType}/{tagPath}
 ```
 
-Values published by integrations for System points (Integration heartbeats, Status, Available, and GenericPoint).
-Subscribe to `BMS/v1/PUB/Metadata/System/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+Values published by integrations for CoolingTower control points.
+Subscribe to `BMS/v1/PUB/Metadata/CoolingTower/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
 That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
-- All integration System values: `BMS/v1/+/Value/System/#`
+- All integration CoolingTower values: `BMS/v1/+/Value/CoolingTower/#`
 
 ### Parameters
 
 | Parameter | Description |
 |-----------|-------------|
 | `integration` | Integration identifier. |
-| `pointType` | Integration-published System point type. Values: `HeartbeatTimestampIntegration`, `HeartbeatEchoIntegration`, `Status`, `Available`, `GenericPoint` |
-| `tagPath` | Vendor-defined hierarchical tag path. |
+| `pointType` | Integration-published CoolingTower point type. Values: `GenericPoint` |
+| `tagPath` | Must match the tagPath from the corresponding BMS metadata exactly. |
 
 ## Message: Point Value
 

--- a/docs/schema-bms-crac-integration-value.mdx
+++ b/docs/schema-bms-crac-integration-value.mdx
@@ -1,30 +1,30 @@
-# System Integration — Value
+# CRAC Integration — Value
 
-Publish integration System values to topics derived from BMS metadata.
+Publish integration values for CRAC control points.
 
 **Direction:** Publish (send)
 
 ## Channel
 
 ```text
-BMS/v1/{integration}/Value/System/{pointType}/{tagPath}
+BMS/v1/{integration}/Value/CRAC/{pointType}/{tagPath}
 ```
 
-Values published by integrations for System points (Integration heartbeats, Status, Available, and GenericPoint).
-Subscribe to `BMS/v1/PUB/Metadata/System/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+Values published by integrations for CRAC control points.
+Subscribe to `BMS/v1/PUB/Metadata/CRAC/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
 That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
-- All integration System values: `BMS/v1/+/Value/System/#`
+- All integration CRAC values: `BMS/v1/+/Value/CRAC/#`
 
 ### Parameters
 
 | Parameter | Description |
 |-----------|-------------|
 | `integration` | Integration identifier. |
-| `pointType` | Integration-published System point type. Values: `HeartbeatTimestampIntegration`, `HeartbeatEchoIntegration`, `Status`, `Available`, `GenericPoint` |
-| `tagPath` | Vendor-defined hierarchical tag path. |
+| `pointType` | Integration-published CRAC point type. Values: `GenericPoint` |
+| `tagPath` | Must match the tagPath from the corresponding BMS metadata exactly. |
 
 ## Message: Point Value
 

--- a/docs/schema-bms-crah-integration-value.mdx
+++ b/docs/schema-bms-crah-integration-value.mdx
@@ -1,30 +1,30 @@
-# System Integration — Value
+# CRAH Integration — Value
 
-Publish integration System values to topics derived from BMS metadata.
+Publish integration values for CRAH control points.
 
 **Direction:** Publish (send)
 
 ## Channel
 
 ```text
-BMS/v1/{integration}/Value/System/{pointType}/{tagPath}
+BMS/v1/{integration}/Value/CRAH/{pointType}/{tagPath}
 ```
 
-Values published by integrations for System points (Integration heartbeats, Status, Available, and GenericPoint).
-Subscribe to `BMS/v1/PUB/Metadata/System/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+Values published by integrations for CRAH control points.
+Subscribe to `BMS/v1/PUB/Metadata/CRAH/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
 That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
-- All integration System values: `BMS/v1/+/Value/System/#`
+- All integration CRAH values: `BMS/v1/+/Value/CRAH/#`
 
 ### Parameters
 
 | Parameter | Description |
 |-----------|-------------|
 | `integration` | Integration identifier. |
-| `pointType` | Integration-published System point type. Values: `HeartbeatTimestampIntegration`, `HeartbeatEchoIntegration`, `Status`, `Available`, `GenericPoint` |
-| `tagPath` | Vendor-defined hierarchical tag path. |
+| `pointType` | Integration-published CRAH point type. Values: `GenericPoint` |
+| `tagPath` | Must match the tagPath from the corresponding BMS metadata exactly. |
 
 ## Message: Point Value
 

--- a/docs/schema-bms-damper-integration-value.mdx
+++ b/docs/schema-bms-damper-integration-value.mdx
@@ -1,30 +1,30 @@
-# System Integration — Value
+# Damper Integration — Value
 
-Publish integration System values to topics derived from BMS metadata.
+Publish integration values for Damper control points.
 
 **Direction:** Publish (send)
 
 ## Channel
 
 ```text
-BMS/v1/{integration}/Value/System/{pointType}/{tagPath}
+BMS/v1/{integration}/Value/Damper/{pointType}/{tagPath}
 ```
 
-Values published by integrations for System points (Integration heartbeats, Status, Available, and GenericPoint).
-Subscribe to `BMS/v1/PUB/Metadata/System/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+Values published by integrations for Damper control points.
+Subscribe to `BMS/v1/PUB/Metadata/Damper/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
 That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
-- All integration System values: `BMS/v1/+/Value/System/#`
+- All integration Damper values: `BMS/v1/+/Value/Damper/#`
 
 ### Parameters
 
 | Parameter | Description |
 |-----------|-------------|
 | `integration` | Integration identifier. |
-| `pointType` | Integration-published System point type. Values: `HeartbeatTimestampIntegration`, `HeartbeatEchoIntegration`, `Status`, `Available`, `GenericPoint` |
-| `tagPath` | Vendor-defined hierarchical tag path. |
+| `pointType` | Integration-published Damper point type. Values: `GenericPoint` |
+| `tagPath` | Must match the tagPath from the corresponding BMS metadata exactly. |
 
 ## Message: Point Value
 

--- a/docs/schema-bms-fan-integration-value.mdx
+++ b/docs/schema-bms-fan-integration-value.mdx
@@ -1,30 +1,30 @@
-# System Integration — Value
+# Fan Integration — Value
 
-Publish integration System values to topics derived from BMS metadata.
+Publish integration values for Fan control points.
 
 **Direction:** Publish (send)
 
 ## Channel
 
 ```text
-BMS/v1/{integration}/Value/System/{pointType}/{tagPath}
+BMS/v1/{integration}/Value/Fan/{pointType}/{tagPath}
 ```
 
-Values published by integrations for System points (Integration heartbeats, Status, Available, and GenericPoint).
-Subscribe to `BMS/v1/PUB/Metadata/System/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+Values published by integrations for Fan control points.
+Subscribe to `BMS/v1/PUB/Metadata/Fan/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
 That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
-- All integration System values: `BMS/v1/+/Value/System/#`
+- All integration Fan values: `BMS/v1/+/Value/Fan/#`
 
 ### Parameters
 
 | Parameter | Description |
 |-----------|-------------|
 | `integration` | Integration identifier. |
-| `pointType` | Integration-published System point type. Values: `HeartbeatTimestampIntegration`, `HeartbeatEchoIntegration`, `Status`, `Available`, `GenericPoint` |
-| `tagPath` | Vendor-defined hierarchical tag path. |
+| `pointType` | Integration-published Fan point type. Values: `GenericPoint` |
+| `tagPath` | Must match the tagPath from the corresponding BMS metadata exactly. |
 
 ## Message: Point Value
 

--- a/docs/schema-bms-generator-integration-value.mdx
+++ b/docs/schema-bms-generator-integration-value.mdx
@@ -1,30 +1,30 @@
-# System Integration — Value
+# Generator Integration — Value
 
-Publish integration System values to topics derived from BMS metadata.
+Publish integration values for Generator control points.
 
 **Direction:** Publish (send)
 
 ## Channel
 
 ```text
-BMS/v1/{integration}/Value/System/{pointType}/{tagPath}
+BMS/v1/{integration}/Value/Generator/{pointType}/{tagPath}
 ```
 
-Values published by integrations for System points (Integration heartbeats, Status, Available, and GenericPoint).
-Subscribe to `BMS/v1/PUB/Metadata/System/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+Values published by integrations for Generator control points.
+Subscribe to `BMS/v1/PUB/Metadata/Generator/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
 That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
-- All integration System values: `BMS/v1/+/Value/System/#`
+- All integration Generator values: `BMS/v1/+/Value/Generator/#`
 
 ### Parameters
 
 | Parameter | Description |
 |-----------|-------------|
 | `integration` | Integration identifier. |
-| `pointType` | Integration-published System point type. Values: `HeartbeatTimestampIntegration`, `HeartbeatEchoIntegration`, `Status`, `Available`, `GenericPoint` |
-| `tagPath` | Vendor-defined hierarchical tag path. |
+| `pointType` | Integration-published Generator point type. Values: `GenericPoint` |
+| `tagPath` | Must match the tagPath from the corresponding BMS metadata exactly. |
 
 ## Message: Point Value
 

--- a/docs/schema-bms-genericobject-integration-value.mdx
+++ b/docs/schema-bms-genericobject-integration-value.mdx
@@ -11,7 +11,8 @@ BMS/v1/{integration}/Value/GenericObject/{pointType}/{tagPath}
 ```
 
 Values published by integrations for GenericObject control points.
-Subscribe to `genericObjectMetadata` first and read `integration` for the exact topic.
+Subscribe to `BMS/v1/PUB/Metadata/GenericObject/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
@@ -22,7 +23,7 @@ Subscribe to `genericObjectMetadata` first and read `integration` for the exact 
 | Parameter | Description |
 |-----------|-------------|
 | `integration` | Integration identifier. |
-| `pointType` | Integration-published GenericObject point type. Values: `LiquidTemperatureSpRequest` |
+| `pointType` | Integration-published GenericObject point type. Values: `LiquidTemperatureSpRequest`, `GenericPoint` |
 | `tagPath` | Must match the tagPath from the corresponding BMS metadata exactly. |
 
 ## Message: Point Value

--- a/docs/schema-bms-hx-integration-value.mdx
+++ b/docs/schema-bms-hx-integration-value.mdx
@@ -1,30 +1,30 @@
-# System Integration — Value
+# HX Integration — Value
 
-Publish integration System values to topics derived from BMS metadata.
+Publish integration values for HX control points.
 
 **Direction:** Publish (send)
 
 ## Channel
 
 ```text
-BMS/v1/{integration}/Value/System/{pointType}/{tagPath}
+BMS/v1/{integration}/Value/HX/{pointType}/{tagPath}
 ```
 
-Values published by integrations for System points (Integration heartbeats, Status, Available, and GenericPoint).
-Subscribe to `BMS/v1/PUB/Metadata/System/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+Values published by integrations for HX control points.
+Subscribe to `BMS/v1/PUB/Metadata/HX/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
 That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
-- All integration System values: `BMS/v1/+/Value/System/#`
+- All integration HX values: `BMS/v1/+/Value/HX/#`
 
 ### Parameters
 
 | Parameter | Description |
 |-----------|-------------|
 | `integration` | Integration identifier. |
-| `pointType` | Integration-published System point type. Values: `HeartbeatTimestampIntegration`, `HeartbeatEchoIntegration`, `Status`, `Available`, `GenericPoint` |
-| `tagPath` | Vendor-defined hierarchical tag path. |
+| `pointType` | Integration-published HX point type. Values: `GenericPoint` |
+| `tagPath` | Must match the tagPath from the corresponding BMS metadata exactly. |
 
 ## Message: Point Value
 

--- a/docs/schema-bms-powermeter-integration-value.mdx
+++ b/docs/schema-bms-powermeter-integration-value.mdx
@@ -1,30 +1,30 @@
-# System Integration — Value
+# Power Meter Integration — Value
 
-Publish integration System values to topics derived from BMS metadata.
+Publish integration values for PowerMeter control points.
 
 **Direction:** Publish (send)
 
 ## Channel
 
 ```text
-BMS/v1/{integration}/Value/System/{pointType}/{tagPath}
+BMS/v1/{integration}/Value/PowerMeter/{pointType}/{tagPath}
 ```
 
-Values published by integrations for System points (Integration heartbeats, Status, Available, and GenericPoint).
-Subscribe to `BMS/v1/PUB/Metadata/System/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+Values published by integrations for PowerMeter control points.
+Subscribe to `BMS/v1/PUB/Metadata/PowerMeter/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
 That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
-- All integration System values: `BMS/v1/+/Value/System/#`
+- All integration PowerMeter values: `BMS/v1/+/Value/PowerMeter/#`
 
 ### Parameters
 
 | Parameter | Description |
 |-----------|-------------|
 | `integration` | Integration identifier. |
-| `pointType` | Integration-published System point type. Values: `HeartbeatTimestampIntegration`, `HeartbeatEchoIntegration`, `Status`, `Available`, `GenericPoint` |
-| `tagPath` | Vendor-defined hierarchical tag path. |
+| `pointType` | Integration-published PowerMeter point type. Values: `GenericPoint` |
+| `tagPath` | Must match the tagPath from the corresponding BMS metadata exactly. |
 
 ## Message: Point Value
 

--- a/docs/schema-bms-pump-integration-value.mdx
+++ b/docs/schema-bms-pump-integration-value.mdx
@@ -1,30 +1,30 @@
-# System Integration — Value
+# Pump Integration — Value
 
-Publish integration System values to topics derived from BMS metadata.
+Publish integration values for Pump control points.
 
 **Direction:** Publish (send)
 
 ## Channel
 
 ```text
-BMS/v1/{integration}/Value/System/{pointType}/{tagPath}
+BMS/v1/{integration}/Value/Pump/{pointType}/{tagPath}
 ```
 
-Values published by integrations for System points (Integration heartbeats, Status, Available, and GenericPoint).
-Subscribe to `BMS/v1/PUB/Metadata/System/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+Values published by integrations for Pump control points.
+Subscribe to `BMS/v1/PUB/Metadata/Pump/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
 That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
-- All integration System values: `BMS/v1/+/Value/System/#`
+- All integration Pump values: `BMS/v1/+/Value/Pump/#`
 
 ### Parameters
 
 | Parameter | Description |
 |-----------|-------------|
 | `integration` | Integration identifier. |
-| `pointType` | Integration-published System point type. Values: `HeartbeatTimestampIntegration`, `HeartbeatEchoIntegration`, `Status`, `Available`, `GenericPoint` |
-| `tagPath` | Vendor-defined hierarchical tag path. |
+| `pointType` | Integration-published Pump point type. Values: `GenericPoint` |
+| `tagPath` | Must match the tagPath from the corresponding BMS metadata exactly. |
 
 ## Message: Point Value
 

--- a/docs/schema-bms-rack-integration-value.mdx
+++ b/docs/schema-bms-rack-integration-value.mdx
@@ -11,10 +11,12 @@ BMS/v1/{integration}/Value/Rack/{pointType}/{tagPath}
 ```
 
 Values published by integrations for Rack control points.
+Subscribe to `BMS/v1/PUB/Metadata/Rack/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
-- All integration rack values: `BMS/v1/+/Value/Rack/#`
+- All integration Rack values: `BMS/v1/+/Value/Rack/#`
 
 ### Parameters
 

--- a/docs/schema-bms-schemas.mdx
+++ b/docs/schema-bms-schemas.mdx
@@ -310,7 +310,7 @@ Valid pointType values for BMS-published generic equipment points.
 
 Valid pointType values for Integration-published generic equipment points.
 
-**Allowed values:** `LiquidTemperatureSpRequest`
+**Allowed values:** `LiquidTemperatureSpRequest`, `GenericPoint`
 
 ---
 
@@ -334,7 +334,7 @@ Valid pointType values for BMS-published System points.
 
 Valid pointType values for Integration-published System points.
 
-**Allowed values:** `HeartbeatTimestampIntegration`, `HeartbeatEchoIntegration`
+**Allowed values:** `HeartbeatTimestampIntegration`, `HeartbeatEchoIntegration`, `Status`, `Available`, `GenericPoint`
 
 ---
 

--- a/docs/schema-bms-sensor-integration-value.mdx
+++ b/docs/schema-bms-sensor-integration-value.mdx
@@ -1,30 +1,30 @@
-# System Integration — Value
+# Sensor Integration — Value
 
-Publish integration System values to topics derived from BMS metadata.
+Publish integration values for Sensor control points.
 
 **Direction:** Publish (send)
 
 ## Channel
 
 ```text
-BMS/v1/{integration}/Value/System/{pointType}/{tagPath}
+BMS/v1/{integration}/Value/Sensor/{pointType}/{tagPath}
 ```
 
-Values published by integrations for System points (Integration heartbeats, Status, Available, and GenericPoint).
-Subscribe to `BMS/v1/PUB/Metadata/System/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+Values published by integrations for Sensor control points.
+Subscribe to `BMS/v1/PUB/Metadata/Sensor/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
 That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
-- All integration System values: `BMS/v1/+/Value/System/#`
+- All integration Sensor values: `BMS/v1/+/Value/Sensor/#`
 
 ### Parameters
 
 | Parameter | Description |
 |-----------|-------------|
 | `integration` | Integration identifier. |
-| `pointType` | Integration-published System point type. Values: `HeartbeatTimestampIntegration`, `HeartbeatEchoIntegration`, `Status`, `Available`, `GenericPoint` |
-| `tagPath` | Vendor-defined hierarchical tag path. |
+| `pointType` | Integration-published Sensor point type. Values: `GenericPoint` |
+| `tagPath` | Must match the tagPath from the corresponding BMS metadata exactly. |
 
 ## Message: Point Value
 

--- a/docs/schema-bms-shunt-integration-value.mdx
+++ b/docs/schema-bms-shunt-integration-value.mdx
@@ -1,30 +1,30 @@
-# System Integration — Value
+# Shunt Integration — Value
 
-Publish integration System values to topics derived from BMS metadata.
+Publish integration values for Shunt control points.
 
 **Direction:** Publish (send)
 
 ## Channel
 
 ```text
-BMS/v1/{integration}/Value/System/{pointType}/{tagPath}
+BMS/v1/{integration}/Value/Shunt/{pointType}/{tagPath}
 ```
 
-Values published by integrations for System points (Integration heartbeats, Status, Available, and GenericPoint).
-Subscribe to `BMS/v1/PUB/Metadata/System/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+Values published by integrations for Shunt control points.
+Subscribe to `BMS/v1/PUB/Metadata/Shunt/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
 That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
-- All integration System values: `BMS/v1/+/Value/System/#`
+- All integration Shunt values: `BMS/v1/+/Value/Shunt/#`
 
 ### Parameters
 
 | Parameter | Description |
 |-----------|-------------|
 | `integration` | Integration identifier. |
-| `pointType` | Integration-published System point type. Values: `HeartbeatTimestampIntegration`, `HeartbeatEchoIntegration`, `Status`, `Available`, `GenericPoint` |
-| `tagPath` | Vendor-defined hierarchical tag path. |
+| `pointType` | Integration-published Shunt point type. Values: `GenericPoint` |
+| `tagPath` | Must match the tagPath from the corresponding BMS metadata exactly. |
 
 ## Message: Point Value
 

--- a/docs/schema-bms-system-metadata.mdx
+++ b/docs/schema-bms-system-metadata.mdx
@@ -134,3 +134,152 @@ BMS-published metadata for all System point types.
 ````
 
 </Accordion>
+
+## Message: System Status Metadata
+
+**Content Type:** `application/json`
+
+### Payload
+
+Optional fields common to all generic equipment metadata, regardless of identifier mode.
+
+### Object Mode
+
+- `objectName` and `objectId` are **required**.
+- `servesId` is **optional** in Named-object mode.
+- `associateId` must **not** be present.
+
+Incompatible with `EquipmentAssociateMode` — validators enforce this via
+the parent `oneOf`.
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `objectName` | string | Yes | Human-readable equipment name. |
+| `objectId` | string | Yes | Stable unique identifier for the equipment. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+
+### Associate Mode
+
+- `associateId` is **required**.
+- `objectName`, `objectId`, and `servesId` must **not** be present.
+
+Incompatible with `EquipmentNamedObjectMode` — validators enforce this
+via the parent `oneOf`.
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `associateId` | string | Yes | Identifier of the associated entity. |
+
+<Accordion title="Example payload">
+
+````json
+{
+  "objectName": "string",
+  "objectId": "string",
+  "servesId": [
+    "string"
+  ]
+}
+````
+
+</Accordion>
+
+## Message: System Available Metadata
+
+**Content Type:** `application/json`
+
+### Payload
+
+Optional fields common to all generic equipment metadata, regardless of identifier mode.
+
+### Object Mode
+
+- `objectName` and `objectId` are **required**.
+- `servesId` is **optional** in Named-object mode.
+- `associateId` must **not** be present.
+
+Incompatible with `EquipmentAssociateMode` — validators enforce this via
+the parent `oneOf`.
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `objectName` | string | Yes | Human-readable equipment name. |
+| `objectId` | string | Yes | Stable unique identifier for the equipment. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+
+### Associate Mode
+
+- `associateId` is **required**.
+- `objectName`, `objectId`, and `servesId` must **not** be present.
+
+Incompatible with `EquipmentNamedObjectMode` — validators enforce this
+via the parent `oneOf`.
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `associateId` | string | Yes | Identifier of the associated entity. |
+
+<Accordion title="Example payload">
+
+````json
+{
+  "objectName": "string",
+  "objectId": "string",
+  "servesId": [
+    "string"
+  ]
+}
+````
+
+</Accordion>
+
+## Message: GenericEquipment GenericPoint Metadata
+
+**Content Type:** `application/json`
+
+### Payload
+
+Field fragment for a vendor-specific or unmapped GenericPoint. `processArea` is required.
+
+`engUnit` and `stateText` are both optional but **mutually exclusive** — include at most one. See the two variants below.
+
+### Object Mode
+
+- `objectName` and `objectId` are **required**.
+- `servesId` is **optional** in Named-object mode.
+- `associateId` must **not** be present.
+
+Incompatible with `EquipmentAssociateMode` — validators enforce this via
+the parent `oneOf`.
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `objectName` | string | Yes | Human-readable equipment name. |
+| `objectId` | string | Yes | Stable unique identifier for the equipment. |
+| `servesId` | array&lt;string&gt; | No | Optional list of objectIds of entities this equipment serves. Only valid in Named-object mode. Only valid in Named-object mode — must not appear in Associate mode. |
+
+### Associate Mode
+
+- `associateId` is **required**.
+- `objectName`, `objectId`, and `servesId` must **not** be present.
+
+Incompatible with `EquipmentNamedObjectMode` — validators enforce this
+via the parent `oneOf`.
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `associateId` | string | Yes | Identifier of the associated entity. |
+
+<Accordion title="Example payload">
+
+````json
+{
+  "objectName": "string",
+  "objectId": "string",
+  "servesId": [
+    "string"
+  ]
+}
+````
+
+</Accordion>

--- a/docs/schema-bms-tank-integration-value.mdx
+++ b/docs/schema-bms-tank-integration-value.mdx
@@ -1,30 +1,30 @@
-# System Integration — Value
+# Tank Integration — Value
 
-Publish integration System values to topics derived from BMS metadata.
+Publish integration values for Tank control points.
 
 **Direction:** Publish (send)
 
 ## Channel
 
 ```text
-BMS/v1/{integration}/Value/System/{pointType}/{tagPath}
+BMS/v1/{integration}/Value/Tank/{pointType}/{tagPath}
 ```
 
-Values published by integrations for System points (Integration heartbeats, Status, Available, and GenericPoint).
-Subscribe to `BMS/v1/PUB/Metadata/System/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+Values published by integrations for Tank control points.
+Subscribe to `BMS/v1/PUB/Metadata/Tank/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
 That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
-- All integration System values: `BMS/v1/+/Value/System/#`
+- All integration Tank values: `BMS/v1/+/Value/Tank/#`
 
 ### Parameters
 
 | Parameter | Description |
 |-----------|-------------|
 | `integration` | Integration identifier. |
-| `pointType` | Integration-published System point type. Values: `HeartbeatTimestampIntegration`, `HeartbeatEchoIntegration`, `Status`, `Available`, `GenericPoint` |
-| `tagPath` | Vendor-defined hierarchical tag path. |
+| `pointType` | Integration-published Tank point type. Values: `GenericPoint` |
+| `tagPath` | Must match the tagPath from the corresponding BMS metadata exactly. |
 
 ## Message: Point Value
 

--- a/docs/schema-bms-ups-integration-value.mdx
+++ b/docs/schema-bms-ups-integration-value.mdx
@@ -1,30 +1,30 @@
-# System Integration — Value
+# UPS Integration — Value
 
-Publish integration System values to topics derived from BMS metadata.
+Publish integration values for UPS control points.
 
 **Direction:** Publish (send)
 
 ## Channel
 
 ```text
-BMS/v1/{integration}/Value/System/{pointType}/{tagPath}
+BMS/v1/{integration}/Value/UPS/{pointType}/{tagPath}
 ```
 
-Values published by integrations for System points (Integration heartbeats, Status, Available, and GenericPoint).
-Subscribe to `BMS/v1/PUB/Metadata/System/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+Values published by integrations for UPS control points.
+Subscribe to `BMS/v1/PUB/Metadata/UPS/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
 That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
-- All integration System values: `BMS/v1/+/Value/System/#`
+- All integration UPS values: `BMS/v1/+/Value/UPS/#`
 
 ### Parameters
 
 | Parameter | Description |
 |-----------|-------------|
 | `integration` | Integration identifier. |
-| `pointType` | Integration-published System point type. Values: `HeartbeatTimestampIntegration`, `HeartbeatEchoIntegration`, `Status`, `Available`, `GenericPoint` |
-| `tagPath` | Vendor-defined hierarchical tag path. |
+| `pointType` | Integration-published UPS point type. Values: `GenericPoint` |
+| `tagPath` | Must match the tagPath from the corresponding BMS metadata exactly. |
 
 ## Message: Point Value
 

--- a/docs/schema-bms-valve-integration-value.mdx
+++ b/docs/schema-bms-valve-integration-value.mdx
@@ -1,30 +1,30 @@
-# System Integration — Value
+# Valve Integration — Value
 
-Publish integration System values to topics derived from BMS metadata.
+Publish integration values for Valve control points.
 
 **Direction:** Publish (send)
 
 ## Channel
 
 ```text
-BMS/v1/{integration}/Value/System/{pointType}/{tagPath}
+BMS/v1/{integration}/Value/Valve/{pointType}/{tagPath}
 ```
 
-Values published by integrations for System points (Integration heartbeats, Status, Available, and GenericPoint).
-Subscribe to `BMS/v1/PUB/Metadata/System/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+Values published by integrations for Valve control points.
+Subscribe to `BMS/v1/PUB/Metadata/Valve/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
 That matching metadata payload indicates the integration can publish values to this topic.
 
 **MQTT wildcard examples**
 
-- All integration System values: `BMS/v1/+/Value/System/#`
+- All integration Valve values: `BMS/v1/+/Value/Valve/#`
 
 ### Parameters
 
 | Parameter | Description |
 |-----------|-------------|
 | `integration` | Integration identifier. |
-| `pointType` | Integration-published System point type. Values: `HeartbeatTimestampIntegration`, `HeartbeatEchoIntegration`, `Status`, `Available`, `GenericPoint` |
-| `tagPath` | Vendor-defined hierarchical tag path. |
+| `pointType` | Integration-published Valve point type. Values: `GenericPoint` |
+| `tagPath` | Must match the tagPath from the corresponding BMS metadata exactly. |
 
 ## Message: Point Value
 

--- a/docs/schema-bms.mdx
+++ b/docs/schema-bms.mdx
@@ -107,6 +107,8 @@ The same contract governs all other integration-published points, including `Rac
 
   - **System**: A System can be the BMS or an Integration to the BMS. Heartbeat points and system-to-system communication point types are typically defined inside of a System object type. System Heartbeat point types are expected to operate as follows. An integration may choose to use the Echo points or not.
 
+    Naming convention: the `BMS`/`Integration` suffix indicates the publisher of the point.
+
     All four heartbeat pointTypes require `objectName` and `objectId` in metadata to identify which System the heartbeat belongs to. By convention, an integration's `objectId` matches the same string used as its `integration` metadata field on its other points (so MEPAI1's System object has `objectId: "MEPAI1"`).
 
     - **HeartbeatTimestampBms** — Publisher: BMS. The BMS publishes its own timestamp every 10 seconds. One instance globally. `objectId` identifies the BMS (e.g., `"BMS"`). `integration` field: not used.
@@ -116,8 +118,6 @@ The same contract governs all other integration-published points, including `Rac
     - **HeartbeatEchoBms** — Publisher: BMS. The BMS reads each integration's `HeartbeatTimestampIntegration` value and re-publishes it on this point type, allowing each integration to confirm round-trip. One instance per connected integration. `objectId` identifies the integration whose timestamp is being echoed (e.g., `"MEPAI1"`). `integration` field: not used.
 
     - **HeartbeatEchoIntegration** — Publisher: Integration. Each integration reads the BMS's `HeartbeatTimestampBms` value and re-publishes it on this point type, allowing the BMS to confirm round-trip with that integration. One per connected integration. `objectId` identifies the BMS being echoed (e.g., `"BMS"`). `integration` field: required (drives topic).
-
-    Naming convention: the `Bms`/`Integration` suffix indicates the publisher of the point. The party whose timestamp is being echoed is encoded in `objectId`, not in the point name.
 
   - **Rack**: A Rack is a special object type and has specific point types that can only be used with a Rack object type. Many integrations and MQTT Clients will only ingest data from the Rack object type. Other integrations will consider Rack data as the most important or interesting data in the AI Factory. Mechanical and Electrical design (and therefore BMS Data) at the rack is also more standardized than mechanical and electrical systems as you move out of the white space and to the gray space of the AI Factory. For these reasons, the point types associated with a Rack object type are generally more specific than any other object type, making ingesting and understanding rack data more straight-forward.
 
@@ -278,6 +278,8 @@ info:
 
       - **System**: A System can be the BMS or an Integration to the BMS. Heartbeat points and system-to-system communication point types are typically defined inside of a System object type. System Heartbeat point types are expected to operate as follows. An integration may choose to use the Echo points or not.
 
+        Naming convention: the `BMS`/`Integration` suffix indicates the publisher of the point.
+
         All four heartbeat pointTypes require `objectName` and `objectId` in metadata to identify which System the heartbeat belongs to. By convention, an integration's `objectId` matches the same string used as its `integration` metadata field on its other points (so MEPAI1's System object has `objectId: "MEPAI1"`).
 
         - **HeartbeatTimestampBms** — Publisher: BMS. The BMS publishes its own timestamp every 10 seconds. One instance globally. `objectId` identifies the BMS (e.g., `"BMS"`). `integration` field: not used.
@@ -287,8 +289,6 @@ info:
         - **HeartbeatEchoBms** — Publisher: BMS. The BMS reads each integration's `HeartbeatTimestampIntegration` value and re-publishes it on this point type, allowing each integration to confirm round-trip. One instance per connected integration. `objectId` identifies the integration whose timestamp is being echoed (e.g., `"MEPAI1"`). `integration` field: not used.
 
         - **HeartbeatEchoIntegration** — Publisher: Integration. Each integration reads the BMS's `HeartbeatTimestampBms` value and re-publishes it on this point type, allowing the BMS to confirm round-trip with that integration. One per connected integration. `objectId` identifies the BMS being echoed (e.g., `"BMS"`). `integration` field: required (drives topic).
-
-        Naming convention: the `Bms`/`Integration` suffix indicates the publisher of the point. The party whose timestamp is being echoed is encoded in `objectId`, not in the point name.
 
       - **Rack**: A Rack is a special object type and has specific point types that can only be used with a Rack object type. Many integrations and MQTT Clients will only ingest data from the Rack object type. Other integrations will consider Rack data as the most important or interesting data in the AI Factory. Mechanical and Electrical design (and therefore BMS Data) at the rack is also more standardized than mechanical and electrical systems as you move out of the white space and to the gray space of the AI Factory. For these reasons, the point types associated with a Rack object type are generally more specific than any other object type, making ingesting and understanding rack data more straight-forward.
 

--- a/docs/schema-bms.mdx
+++ b/docs/schema-bms.mdx
@@ -440,10 +440,12 @@ channels:
     address: 'BMS/v1/{integration}/Value/Rack/{pointType}/{tagPath}'
     description: |
       Values published by integrations for Rack control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Rack/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
 
       **MQTT wildcard examples**
 
-      - All integration rack values: `BMS/v1/+/Value/Rack/#`
+      - All integration Rack values: `BMS/v1/+/Value/Rack/#`
     parameters:
       integration:
         description: Integration identifier.
@@ -533,6 +535,29 @@ channels:
       phaseCurrent:
         $ref: '#/components/messages/PowerMeterPhaseCurrentMsg'
 
+  powerMeterIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/PowerMeter/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for PowerMeter control points.
+      Subscribe to `BMS/v1/PUB/Metadata/PowerMeter/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration PowerMeter values: `BMS/v1/+/Value/PowerMeter/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published PowerMeter point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
+
   # ---------------------------------------------------------------------------
   # BESS
   # ---------------------------------------------------------------------------
@@ -583,6 +608,29 @@ channels:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
       available:
         $ref: '#/components/messages/BESSAvailableMsg'
+
+  bessIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/BESS/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for BESS control points.
+      Subscribe to `BMS/v1/PUB/Metadata/BESS/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration BESS values: `BMS/v1/+/Value/BESS/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published BESS point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
 
   # ---------------------------------------------------------------------------
   # UPS
@@ -635,6 +683,29 @@ channels:
       available:
         $ref: '#/components/messages/UPSAvailableMsg'
 
+  upsIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/UPS/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for UPS control points.
+      Subscribe to `BMS/v1/PUB/Metadata/UPS/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration UPS values: `BMS/v1/+/Value/UPS/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published UPS point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
+
   # ---------------------------------------------------------------------------
   # ATS
   # ---------------------------------------------------------------------------
@@ -685,6 +756,29 @@ channels:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
       available:
         $ref: '#/components/messages/ATSAvailableMsg'
+
+  atsIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/ATS/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for ATS control points.
+      Subscribe to `BMS/v1/PUB/Metadata/ATS/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration ATS values: `BMS/v1/+/Value/ATS/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published ATS point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
 
   # ---------------------------------------------------------------------------
   # Generator
@@ -737,6 +831,29 @@ channels:
       available:
         $ref: '#/components/messages/GeneratorAvailableMsg'
 
+  generatorIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/Generator/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for Generator control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Generator/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration Generator values: `BMS/v1/+/Value/Generator/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published Generator point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
+
   # ---------------------------------------------------------------------------
   # Shunt
   # ---------------------------------------------------------------------------
@@ -787,6 +904,29 @@ channels:
       available:
         $ref: '#/components/messages/ShuntAvailableMsg'
 
+  shuntIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/Shunt/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for Shunt control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Shunt/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration Shunt values: `BMS/v1/+/Value/Shunt/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published Shunt point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
+
   # ---------------------------------------------------------------------------
   # Breaker
   # ---------------------------------------------------------------------------
@@ -836,6 +976,29 @@ channels:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
       available:
         $ref: '#/components/messages/BreakerAvailableMsg'
+
+  breakerIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/Breaker/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for Breaker control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Breaker/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration Breaker values: `BMS/v1/+/Value/Breaker/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published Breaker point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
 
   # ---------------------------------------------------------------------------
   # CDU
@@ -951,7 +1114,8 @@ channels:
     address: 'BMS/v1/{integration}/Value/CDU/{pointType}/{tagPath}'
     description: |
       Values published by integrations for CDU control points.
-      Subscribe to `cduMetadata` first and read `integration` for the exact topic.
+      Subscribe to `BMS/v1/PUB/Metadata/CDU/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
 
       **MQTT wildcard examples**
 
@@ -962,6 +1126,7 @@ channels:
       pointType:
         enum:
           - LiquidTemperatureSpRequest
+          - GenericPoint
         description: Integration-published CDU point type.
       tagPath:
         description: Must match the tagPath from the corresponding BMS metadata exactly.
@@ -1075,6 +1240,29 @@ channels:
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
 
+  coolingTowerIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/CoolingTower/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for CoolingTower control points.
+      Subscribe to `BMS/v1/PUB/Metadata/CoolingTower/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration CoolingTower values: `BMS/v1/+/Value/CoolingTower/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published CoolingTower point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
+
   # ---------------------------------------------------------------------------
   # HX
   # ---------------------------------------------------------------------------
@@ -1180,6 +1368,29 @@ channels:
         $ref: '#/components/messages/HXLeakDetectMsg'
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
+
+  hxIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/HX/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for HX control points.
+      Subscribe to `BMS/v1/PUB/Metadata/HX/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration HX values: `BMS/v1/+/Value/HX/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published HX point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
 
   # ---------------------------------------------------------------------------
   # CRAH
@@ -1287,6 +1498,29 @@ channels:
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
 
+  crahIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/CRAH/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for CRAH control points.
+      Subscribe to `BMS/v1/PUB/Metadata/CRAH/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration CRAH values: `BMS/v1/+/Value/CRAH/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published CRAH point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
+
   # ---------------------------------------------------------------------------
   # CRAC
   # ---------------------------------------------------------------------------
@@ -1392,6 +1626,29 @@ channels:
         $ref: '#/components/messages/CRACLeakDetectMsg'
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
+
+  cracIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/CRAC/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for CRAC control points.
+      Subscribe to `BMS/v1/PUB/Metadata/CRAC/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration CRAC values: `BMS/v1/+/Value/CRAC/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published CRAC point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
 
   # ---------------------------------------------------------------------------
   # AHU
@@ -1499,6 +1756,29 @@ channels:
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
 
+  ahuIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/AHU/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for AHU control points.
+      Subscribe to `BMS/v1/PUB/Metadata/AHU/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration AHU values: `BMS/v1/+/Value/AHU/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published AHU point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
+
   # ---------------------------------------------------------------------------
   # Chiller
   # ---------------------------------------------------------------------------
@@ -1605,6 +1885,29 @@ channels:
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
 
+  chillerIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/Chiller/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for Chiller control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Chiller/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration Chiller values: `BMS/v1/+/Value/Chiller/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published Chiller point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
+
   # ---------------------------------------------------------------------------
   # Valve
   # ---------------------------------------------------------------------------
@@ -1654,6 +1957,29 @@ channels:
         $ref: '#/components/messages/ValveAvailableMsg'
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
+
+  valveIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/Valve/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for Valve control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Valve/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration Valve values: `BMS/v1/+/Value/Valve/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published Valve point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
 
   # ---------------------------------------------------------------------------
   # Pump
@@ -1705,6 +2031,29 @@ channels:
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
 
+  pumpIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/Pump/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for Pump control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Pump/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration Pump values: `BMS/v1/+/Value/Pump/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published Pump point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
+
   # ---------------------------------------------------------------------------
   # Fan
   # ---------------------------------------------------------------------------
@@ -1755,6 +2104,29 @@ channels:
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
 
+  fanIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/Fan/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for Fan control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Fan/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration Fan values: `BMS/v1/+/Value/Fan/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published Fan point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
+
   # ---------------------------------------------------------------------------
   # Damper
   # ---------------------------------------------------------------------------
@@ -1804,6 +2176,29 @@ channels:
         $ref: '#/components/messages/DamperAvailableMsg'
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
+
+  damperIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/Damper/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for Damper control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Damper/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration Damper values: `BMS/v1/+/Value/Damper/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published Damper point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
 
   # ---------------------------------------------------------------------------
   # Sensor
@@ -1894,6 +2289,29 @@ channels:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
       sound:
         $ref: '#/components/messages/SensorSoundMsg'
+
+  sensorIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/Sensor/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for Sensor control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Sensor/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration Sensor values: `BMS/v1/+/Value/Sensor/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published Sensor point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
 
   # ---------------------------------------------------------------------------
   # Tank
@@ -2002,6 +2420,29 @@ channels:
         $ref: '#/components/messages/TankLeakDetectMsg'
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
+
+  tankIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/Tank/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for Tank control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Tank/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration Tank values: `BMS/v1/+/Value/Tank/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published Tank point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
 
   # ---------------------------------------------------------------------------
   # GenericObject
@@ -2122,7 +2563,8 @@ channels:
     address: 'BMS/v1/{integration}/Value/GenericObject/{pointType}/{tagPath}'
     description: |
       Values published by integrations for GenericObject control points.
-      Subscribe to `genericObjectMetadata` first and read `integration` for the exact topic.
+      Subscribe to `BMS/v1/PUB/Metadata/GenericObject/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
 
       **MQTT wildcard examples**
 
@@ -2133,6 +2575,7 @@ channels:
       pointType:
         enum:
           - LiquidTemperatureSpRequest
+          - GenericPoint
         description: Integration-published GenericObject point type.
       tagPath:
         description: Must match the tagPath from the corresponding BMS metadata exactly.
@@ -2207,11 +2650,13 @@ channels:
   systemIntegrationValue:
     address: 'BMS/v1/{integration}/Value/System/{pointType}/{tagPath}'
     description: |
-      Values published by integrations for Heartbeat points.
+      Values published by integrations for System points (Integration heartbeats, Status, Available, and GenericPoint).
+      Subscribe to `BMS/v1/PUB/Metadata/System/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
 
       **MQTT wildcard examples**
 
-      - All integration heartbeat values: `BMS/v1/+/Value/System/#`
+      - All integration System values: `BMS/v1/+/Value/System/#`
     parameters:
       integration:
         description: Integration identifier.
@@ -2219,6 +2664,9 @@ channels:
         enum:
           - HeartbeatTimestampIntegration
           - HeartbeatEchoIntegration
+          - Status
+          - Available
+          - GenericPoint
         description: Integration-published System point type.
       tagPath:
         description: Vendor-defined hierarchical tag path.
@@ -2293,6 +2741,14 @@ operations:
       - $ref: '#/channels/powerMeterMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for all PowerMeter points.
 
+  publishPowerMeterIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/powerMeterIntegrationValue'
+    messages:
+      - $ref: '#/channels/powerMeterIntegrationValue/messages/valueMessage'
+    description: Publish integration values for PowerMeter control points.
+
   receiveBESSValue:
     action: receive
     channel:
@@ -2310,6 +2766,14 @@ operations:
       - $ref: '#/channels/bessMetadata/messages/available'
       - $ref: '#/channels/bessMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for BESS points.
+
+  publishBESSIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/bessIntegrationValue'
+    messages:
+      - $ref: '#/channels/bessIntegrationValue/messages/valueMessage'
+    description: Publish integration values for BESS control points.
 
   receiveUPSValue:
     action: receive
@@ -2329,6 +2793,14 @@ operations:
       - $ref: '#/channels/upsMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for UPS points.
 
+  publishUPSIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/upsIntegrationValue'
+    messages:
+      - $ref: '#/channels/upsIntegrationValue/messages/valueMessage'
+    description: Publish integration values for UPS control points.
+
   receiveATSValue:
     action: receive
     channel:
@@ -2346,6 +2818,14 @@ operations:
       - $ref: '#/channels/atsMetadata/messages/available'
       - $ref: '#/channels/atsMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for ATS points.
+
+  publishATSIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/atsIntegrationValue'
+    messages:
+      - $ref: '#/channels/atsIntegrationValue/messages/valueMessage'
+    description: Publish integration values for ATS control points.
 
   receiveGeneratorValue:
     action: receive
@@ -2365,6 +2845,14 @@ operations:
       - $ref: '#/channels/generatorMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for Generator points.
 
+  publishGeneratorIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/generatorIntegrationValue'
+    messages:
+      - $ref: '#/channels/generatorIntegrationValue/messages/valueMessage'
+    description: Publish integration values for Generator control points.
+
   receiveShuntValue:
     action: receive
     channel:
@@ -2383,6 +2871,14 @@ operations:
       - $ref: '#/channels/shuntMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for Shunt points.
 
+  publishShuntIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/shuntIntegrationValue'
+    messages:
+      - $ref: '#/channels/shuntIntegrationValue/messages/valueMessage'
+    description: Publish integration values for Shunt control points.
+
   receiveBreakerValue:
     action: receive
     channel:
@@ -2400,6 +2896,14 @@ operations:
       - $ref: '#/channels/breakerMetadata/messages/available'
       - $ref: '#/channels/breakerMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for Breaker points.
+
+  publishBreakerIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/breakerIntegrationValue'
+    messages:
+      - $ref: '#/channels/breakerIntegrationValue/messages/valueMessage'
+    description: Publish integration values for Breaker control points.
 
   receiveCDUValue:
     action: receive
@@ -2474,6 +2978,14 @@ operations:
       - $ref: '#/channels/coolingTowerMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for CoolingTower points.
 
+  publishCoolingTowerIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/coolingTowerIntegrationValue'
+    messages:
+      - $ref: '#/channels/coolingTowerIntegrationValue/messages/valueMessage'
+    description: Publish integration values for CoolingTower control points.
+
   receiveHXValue:
     action: receive
     channel:
@@ -2505,6 +3017,14 @@ operations:
       - $ref: '#/channels/hxMetadata/messages/leakDetect'
       - $ref: '#/channels/hxMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for HX points.
+
+  publishHXIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/hxIntegrationValue'
+    messages:
+      - $ref: '#/channels/hxIntegrationValue/messages/valueMessage'
+    description: Publish integration values for HX control points.
 
   receiveCRAHValue:
     action: receive
@@ -2538,6 +3058,14 @@ operations:
       - $ref: '#/channels/crahMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for CRAH points.
 
+  publishCRAHIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/crahIntegrationValue'
+    messages:
+      - $ref: '#/channels/crahIntegrationValue/messages/valueMessage'
+    description: Publish integration values for CRAH control points.
+
   receiveCRACValue:
     action: receive
     channel:
@@ -2569,6 +3097,14 @@ operations:
       - $ref: '#/channels/cracMetadata/messages/leakDetect'
       - $ref: '#/channels/cracMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for CRAC points.
+
+  publishCRACIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/cracIntegrationValue'
+    messages:
+      - $ref: '#/channels/cracIntegrationValue/messages/valueMessage'
+    description: Publish integration values for CRAC control points.
 
   receiveAHUValue:
     action: receive
@@ -2602,6 +3138,14 @@ operations:
       - $ref: '#/channels/ahuMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for AHU points.
 
+  publishAHUIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/ahuIntegrationValue'
+    messages:
+      - $ref: '#/channels/ahuIntegrationValue/messages/valueMessage'
+    description: Publish integration values for AHU control points.
+
   receiveChillerValue:
     action: receive
     channel:
@@ -2634,6 +3178,14 @@ operations:
       - $ref: '#/channels/chillerMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for Chiller points.
 
+  publishChillerIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/chillerIntegrationValue'
+    messages:
+      - $ref: '#/channels/chillerIntegrationValue/messages/valueMessage'
+    description: Publish integration values for Chiller control points.
+
   receiveValveValue:
     action: receive
     channel:
@@ -2651,6 +3203,14 @@ operations:
       - $ref: '#/channels/valveMetadata/messages/available'
       - $ref: '#/channels/valveMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for Valve points.
+
+  publishValveIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/valveIntegrationValue'
+    messages:
+      - $ref: '#/channels/valveIntegrationValue/messages/valueMessage'
+    description: Publish integration values for Valve control points.
 
   receivePumpValue:
     action: receive
@@ -2670,6 +3230,14 @@ operations:
       - $ref: '#/channels/pumpMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for Pump points.
 
+  publishPumpIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/pumpIntegrationValue'
+    messages:
+      - $ref: '#/channels/pumpIntegrationValue/messages/valueMessage'
+    description: Publish integration values for Pump control points.
+
   receiveFanValue:
     action: receive
     channel:
@@ -2688,6 +3256,14 @@ operations:
       - $ref: '#/channels/fanMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for Fan points.
 
+  publishFanIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/fanIntegrationValue'
+    messages:
+      - $ref: '#/channels/fanIntegrationValue/messages/valueMessage'
+    description: Publish integration values for Fan control points.
+
   receiveDamperValue:
     action: receive
     channel:
@@ -2705,6 +3281,14 @@ operations:
       - $ref: '#/channels/damperMetadata/messages/available'
       - $ref: '#/channels/damperMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for Damper points.
+
+  publishDamperIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/damperIntegrationValue'
+    messages:
+      - $ref: '#/channels/damperIntegrationValue/messages/valueMessage'
+    description: Publish integration values for Damper control points.
 
   receiveSensorValue:
     action: receive
@@ -2733,6 +3317,14 @@ operations:
       - $ref: '#/channels/sensorMetadata/messages/sound'
       - $ref: '#/channels/sensorMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for Sensor points.
+
+  publishSensorIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/sensorIntegrationValue'
+    messages:
+      - $ref: '#/channels/sensorIntegrationValue/messages/valueMessage'
+    description: Publish integration values for Sensor control points.
 
   receiveTankValue:
     action: receive
@@ -2765,6 +3357,14 @@ operations:
       - $ref: '#/channels/tankMetadata/messages/leakDetect'
       - $ref: '#/channels/tankMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for Tank points.
+
+  publishTankIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/tankIntegrationValue'
+    messages:
+      - $ref: '#/channels/tankIntegrationValue/messages/valueMessage'
+    description: Publish integration values for Tank control points.
 
   receiveGenericObjectValue:
     action: receive
@@ -2825,6 +3425,9 @@ operations:
       - $ref: '#/channels/systemMetadata/messages/heartbeatEchoBms'
       - $ref: '#/channels/systemMetadata/messages/heartbeatTimestampIntegration'
       - $ref: '#/channels/systemMetadata/messages/heartbeatEchoIntegration'
+      - $ref: '#/channels/systemMetadata/messages/status'
+      - $ref: '#/channels/systemMetadata/messages/available'
+      - $ref: '#/channels/systemMetadata/messages/genericPoint'
     description: Subscribe to System metadata for all System point types.
 
   publishSystemIntegrationValue:
@@ -4583,6 +5186,7 @@ components:
       description: Valid pointType values for Integration-published generic equipment points.
       enum:
         - LiquidTemperatureSpRequest
+        - GenericPoint
 
     EquipmentObjectType:
       type: string
@@ -4625,6 +5229,9 @@ components:
       enum:
         - HeartbeatTimestampIntegration
         - HeartbeatEchoIntegration
+        - Status
+        - Available
+        - GenericPoint
 
     # =========================================================================
     # SECTION 4 — Per-pointType field fragments

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -77,6 +77,9 @@ navigation:
                   - page: Value
                     path: ../docs/schema-bms-ahu-value.mdx
                     slug: ahu-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-ahu-integration-value.mdx
+                    slug: ahu-integration-value
               - section: ATS
                 contents:
                   - page: Metadata
@@ -85,6 +88,9 @@ navigation:
                   - page: Value
                     path: ../docs/schema-bms-ats-value.mdx
                     slug: ats-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-ats-integration-value.mdx
+                    slug: ats-integration-value
               - section: BESS
                 contents:
                   - page: Metadata
@@ -93,6 +99,9 @@ navigation:
                   - page: Value
                     path: ../docs/schema-bms-bess-value.mdx
                     slug: bess-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-bess-integration-value.mdx
+                    slug: bess-integration-value
               - section: Breaker
                 contents:
                   - page: Metadata
@@ -101,17 +110,20 @@ navigation:
                   - page: Value
                     path: ../docs/schema-bms-breaker-value.mdx
                     slug: breaker-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-breaker-integration-value.mdx
+                    slug: breaker-integration-value
               - section: CDU
                 contents:
-                  - page: Integration Value
-                    path: ../docs/schema-bms-cdu-integration-value.mdx
-                    slug: cdu-integration-value
                   - page: Metadata
                     path: ../docs/schema-bms-cdu-metadata.mdx
                     slug: cdu-metadata
                   - page: Value
                     path: ../docs/schema-bms-cdu-value.mdx
                     slug: cdu-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-cdu-integration-value.mdx
+                    slug: cdu-integration-value
               - section: Chiller
                 contents:
                   - page: Metadata
@@ -120,6 +132,9 @@ navigation:
                   - page: Value
                     path: ../docs/schema-bms-chiller-value.mdx
                     slug: chiller-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-chiller-integration-value.mdx
+                    slug: chiller-integration-value
               - section: Cooling Tower
                 contents:
                   - page: Metadata
@@ -128,6 +143,9 @@ navigation:
                   - page: Value
                     path: ../docs/schema-bms-coolingtower-value.mdx
                     slug: coolingtower-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-coolingtower-integration-value.mdx
+                    slug: coolingtower-integration-value
               - section: CRAC
                 contents:
                   - page: Metadata
@@ -136,6 +154,9 @@ navigation:
                   - page: Value
                     path: ../docs/schema-bms-crac-value.mdx
                     slug: crac-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-crac-integration-value.mdx
+                    slug: crac-integration-value
               - section: CRAH
                 contents:
                   - page: Metadata
@@ -144,6 +165,9 @@ navigation:
                   - page: Value
                     path: ../docs/schema-bms-crah-value.mdx
                     slug: crah-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-crah-integration-value.mdx
+                    slug: crah-integration-value
               - section: Damper
                 contents:
                   - page: Metadata
@@ -152,6 +176,9 @@ navigation:
                   - page: Value
                     path: ../docs/schema-bms-damper-value.mdx
                     slug: damper-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-damper-integration-value.mdx
+                    slug: damper-integration-value
               - section: Fan
                 contents:
                   - page: Metadata
@@ -160,6 +187,9 @@ navigation:
                   - page: Value
                     path: ../docs/schema-bms-fan-value.mdx
                     slug: fan-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-fan-integration-value.mdx
+                    slug: fan-integration-value
               - section: Generator
                 contents:
                   - page: Metadata
@@ -168,17 +198,20 @@ navigation:
                   - page: Value
                     path: ../docs/schema-bms-generator-value.mdx
                     slug: generator-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-generator-integration-value.mdx
+                    slug: generator-integration-value
               - section: Generic Object
                 contents:
-                  - page: Integration Value
-                    path: ../docs/schema-bms-genericobject-integration-value.mdx
-                    slug: genericobject-integration-value
                   - page: Metadata
                     path: ../docs/schema-bms-genericobject-metadata.mdx
                     slug: genericobject-metadata
                   - page: Value
                     path: ../docs/schema-bms-genericobject-value.mdx
                     slug: genericobject-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-genericobject-integration-value.mdx
+                    slug: genericobject-integration-value
               - section: HX
                 contents:
                   - page: Metadata
@@ -187,6 +220,9 @@ navigation:
                   - page: Value
                     path: ../docs/schema-bms-hx-value.mdx
                     slug: hx-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-hx-integration-value.mdx
+                    slug: hx-integration-value
               - section: Power Meter
                 contents:
                   - page: Metadata
@@ -195,6 +231,9 @@ navigation:
                   - page: Value
                     path: ../docs/schema-bms-powermeter-value.mdx
                     slug: powermeter-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-powermeter-integration-value.mdx
+                    slug: powermeter-integration-value
               - section: Pump
                 contents:
                   - page: Metadata
@@ -203,17 +242,20 @@ navigation:
                   - page: Value
                     path: ../docs/schema-bms-pump-value.mdx
                     slug: pump-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-pump-integration-value.mdx
+                    slug: pump-integration-value
               - section: Rack
                 contents:
-                  - page: Integration Value
-                    path: ../docs/schema-bms-rack-integration-value.mdx
-                    slug: rack-integration-value
                   - page: Metadata
                     path: ../docs/schema-bms-rack-metadata.mdx
                     slug: rack-metadata
                   - page: Value
                     path: ../docs/schema-bms-rack-value.mdx
                     slug: rack-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-rack-integration-value.mdx
+                    slug: rack-integration-value
               - section: Sensor
                 contents:
                   - page: Metadata
@@ -222,6 +264,9 @@ navigation:
                   - page: Value
                     path: ../docs/schema-bms-sensor-value.mdx
                     slug: sensor-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-sensor-integration-value.mdx
+                    slug: sensor-integration-value
               - section: Shunt
                 contents:
                   - page: Metadata
@@ -230,17 +275,20 @@ navigation:
                   - page: Value
                     path: ../docs/schema-bms-shunt-value.mdx
                     slug: shunt-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-shunt-integration-value.mdx
+                    slug: shunt-integration-value
               - section: System
                 contents:
+                  - page: Metadata
+                    path: ../docs/schema-bms-system-metadata.mdx
+                    slug: system-metadata
                   - page: BMS Value
                     path: ../docs/schema-bms-system-bms-value.mdx
                     slug: system-bms-value
                   - page: Integration Value
                     path: ../docs/schema-bms-system-integration-value.mdx
                     slug: system-integration-value
-                  - page: Metadata
-                    path: ../docs/schema-bms-system-metadata.mdx
-                    slug: system-metadata
               - section: Tank
                 contents:
                   - page: Metadata
@@ -249,6 +297,9 @@ navigation:
                   - page: Value
                     path: ../docs/schema-bms-tank-value.mdx
                     slug: tank-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-tank-integration-value.mdx
+                    slug: tank-integration-value
               - section: UPS
                 contents:
                   - page: Metadata
@@ -257,6 +308,9 @@ navigation:
                   - page: Value
                     path: ../docs/schema-bms-ups-value.mdx
                     slug: ups-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-ups-integration-value.mdx
+                    slug: ups-integration-value
               - section: Valve
                 contents:
                   - page: Metadata
@@ -265,6 +319,9 @@ navigation:
                   - page: Value
                     path: ../docs/schema-bms-valve-value.mdx
                     slug: valve-value
+                  - page: Integration Value
+                    path: ../docs/schema-bms-valve-integration-value.mdx
+                    slug: valve-integration-value
           - page: Messages
             path: ../docs/schema-bms-messages.mdx
             slug: messages

--- a/schemas/asyncapi/bms/bms.yaml
+++ b/schemas/asyncapi/bms/bms.yaml
@@ -280,10 +280,12 @@ channels:
     address: 'BMS/v1/{integration}/Value/Rack/{pointType}/{tagPath}'
     description: |
       Values published by integrations for Rack control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Rack/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
 
       **MQTT wildcard examples**
 
-      - All integration rack values: `BMS/v1/+/Value/Rack/#`
+      - All integration Rack values: `BMS/v1/+/Value/Rack/#`
     parameters:
       integration:
         description: Integration identifier.
@@ -373,6 +375,29 @@ channels:
       phaseCurrent:
         $ref: '#/components/messages/PowerMeterPhaseCurrentMsg'
 
+  powerMeterIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/PowerMeter/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for PowerMeter control points.
+      Subscribe to `BMS/v1/PUB/Metadata/PowerMeter/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration PowerMeter values: `BMS/v1/+/Value/PowerMeter/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published PowerMeter point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
+
   # ---------------------------------------------------------------------------
   # BESS
   # ---------------------------------------------------------------------------
@@ -423,6 +448,29 @@ channels:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
       available:
         $ref: '#/components/messages/BESSAvailableMsg'
+
+  bessIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/BESS/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for BESS control points.
+      Subscribe to `BMS/v1/PUB/Metadata/BESS/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration BESS values: `BMS/v1/+/Value/BESS/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published BESS point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
 
   # ---------------------------------------------------------------------------
   # UPS
@@ -475,6 +523,29 @@ channels:
       available:
         $ref: '#/components/messages/UPSAvailableMsg'
 
+  upsIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/UPS/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for UPS control points.
+      Subscribe to `BMS/v1/PUB/Metadata/UPS/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration UPS values: `BMS/v1/+/Value/UPS/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published UPS point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
+
   # ---------------------------------------------------------------------------
   # ATS
   # ---------------------------------------------------------------------------
@@ -525,6 +596,29 @@ channels:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
       available:
         $ref: '#/components/messages/ATSAvailableMsg'
+
+  atsIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/ATS/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for ATS control points.
+      Subscribe to `BMS/v1/PUB/Metadata/ATS/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration ATS values: `BMS/v1/+/Value/ATS/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published ATS point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
 
   # ---------------------------------------------------------------------------
   # Generator
@@ -577,6 +671,29 @@ channels:
       available:
         $ref: '#/components/messages/GeneratorAvailableMsg'
 
+  generatorIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/Generator/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for Generator control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Generator/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration Generator values: `BMS/v1/+/Value/Generator/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published Generator point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
+
   # ---------------------------------------------------------------------------
   # Shunt
   # ---------------------------------------------------------------------------
@@ -627,6 +744,29 @@ channels:
       available:
         $ref: '#/components/messages/ShuntAvailableMsg'
 
+  shuntIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/Shunt/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for Shunt control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Shunt/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration Shunt values: `BMS/v1/+/Value/Shunt/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published Shunt point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
+
   # ---------------------------------------------------------------------------
   # Breaker
   # ---------------------------------------------------------------------------
@@ -676,6 +816,29 @@ channels:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
       available:
         $ref: '#/components/messages/BreakerAvailableMsg'
+
+  breakerIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/Breaker/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for Breaker control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Breaker/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration Breaker values: `BMS/v1/+/Value/Breaker/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published Breaker point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
 
   # ---------------------------------------------------------------------------
   # CDU
@@ -791,7 +954,8 @@ channels:
     address: 'BMS/v1/{integration}/Value/CDU/{pointType}/{tagPath}'
     description: |
       Values published by integrations for CDU control points.
-      Subscribe to `cduMetadata` first and read `integration` for the exact topic.
+      Subscribe to `BMS/v1/PUB/Metadata/CDU/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
 
       **MQTT wildcard examples**
 
@@ -802,6 +966,7 @@ channels:
       pointType:
         enum:
           - LiquidTemperatureSpRequest
+          - GenericPoint
         description: Integration-published CDU point type.
       tagPath:
         description: Must match the tagPath from the corresponding BMS metadata exactly.
@@ -915,6 +1080,29 @@ channels:
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
 
+  coolingTowerIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/CoolingTower/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for CoolingTower control points.
+      Subscribe to `BMS/v1/PUB/Metadata/CoolingTower/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration CoolingTower values: `BMS/v1/+/Value/CoolingTower/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published CoolingTower point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
+
   # ---------------------------------------------------------------------------
   # HX
   # ---------------------------------------------------------------------------
@@ -1020,6 +1208,29 @@ channels:
         $ref: '#/components/messages/HXLeakDetectMsg'
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
+
+  hxIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/HX/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for HX control points.
+      Subscribe to `BMS/v1/PUB/Metadata/HX/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration HX values: `BMS/v1/+/Value/HX/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published HX point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
 
   # ---------------------------------------------------------------------------
   # CRAH
@@ -1127,6 +1338,29 @@ channels:
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
 
+  crahIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/CRAH/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for CRAH control points.
+      Subscribe to `BMS/v1/PUB/Metadata/CRAH/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration CRAH values: `BMS/v1/+/Value/CRAH/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published CRAH point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
+
   # ---------------------------------------------------------------------------
   # CRAC
   # ---------------------------------------------------------------------------
@@ -1232,6 +1466,29 @@ channels:
         $ref: '#/components/messages/CRACLeakDetectMsg'
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
+
+  cracIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/CRAC/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for CRAC control points.
+      Subscribe to `BMS/v1/PUB/Metadata/CRAC/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration CRAC values: `BMS/v1/+/Value/CRAC/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published CRAC point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
 
   # ---------------------------------------------------------------------------
   # AHU
@@ -1339,6 +1596,29 @@ channels:
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
 
+  ahuIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/AHU/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for AHU control points.
+      Subscribe to `BMS/v1/PUB/Metadata/AHU/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration AHU values: `BMS/v1/+/Value/AHU/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published AHU point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
+
   # ---------------------------------------------------------------------------
   # Chiller
   # ---------------------------------------------------------------------------
@@ -1445,6 +1725,29 @@ channels:
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
 
+  chillerIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/Chiller/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for Chiller control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Chiller/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration Chiller values: `BMS/v1/+/Value/Chiller/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published Chiller point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
+
   # ---------------------------------------------------------------------------
   # Valve
   # ---------------------------------------------------------------------------
@@ -1494,6 +1797,29 @@ channels:
         $ref: '#/components/messages/ValveAvailableMsg'
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
+
+  valveIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/Valve/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for Valve control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Valve/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration Valve values: `BMS/v1/+/Value/Valve/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published Valve point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
 
   # ---------------------------------------------------------------------------
   # Pump
@@ -1545,6 +1871,29 @@ channels:
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
 
+  pumpIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/Pump/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for Pump control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Pump/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration Pump values: `BMS/v1/+/Value/Pump/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published Pump point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
+
   # ---------------------------------------------------------------------------
   # Fan
   # ---------------------------------------------------------------------------
@@ -1595,6 +1944,29 @@ channels:
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
 
+  fanIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/Fan/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for Fan control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Fan/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration Fan values: `BMS/v1/+/Value/Fan/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published Fan point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
+
   # ---------------------------------------------------------------------------
   # Damper
   # ---------------------------------------------------------------------------
@@ -1644,6 +2016,29 @@ channels:
         $ref: '#/components/messages/DamperAvailableMsg'
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
+
+  damperIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/Damper/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for Damper control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Damper/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration Damper values: `BMS/v1/+/Value/Damper/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published Damper point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
 
   # ---------------------------------------------------------------------------
   # Sensor
@@ -1735,6 +2130,29 @@ channels:
       sound:
         $ref: '#/components/messages/SensorSoundMsg'
 
+
+  sensorIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/Sensor/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for Sensor control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Sensor/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration Sensor values: `BMS/v1/+/Value/Sensor/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published Sensor point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
 
   # ---------------------------------------------------------------------------
   # Tank
@@ -1843,6 +2261,29 @@ channels:
         $ref: '#/components/messages/TankLeakDetectMsg'
       genericPoint:
         $ref: '#/components/messages/GenericEquipmentPointMsg'
+
+  tankIntegrationValue:
+    address: 'BMS/v1/{integration}/Value/Tank/{pointType}/{tagPath}'
+    description: |
+      Values published by integrations for Tank control points.
+      Subscribe to `BMS/v1/PUB/Metadata/Tank/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
+
+      **MQTT wildcard examples**
+
+      - All integration Tank values: `BMS/v1/+/Value/Tank/#`
+    parameters:
+      integration:
+        description: Integration identifier.
+      pointType:
+        enum:
+          - GenericPoint
+        description: Integration-published Tank point type.
+      tagPath:
+        description: Must match the tagPath from the corresponding BMS metadata exactly.
+    messages:
+      valueMessage:
+        $ref: '#/components/messages/ValueMessage'
 
   # ---------------------------------------------------------------------------
   # GenericObject
@@ -1963,7 +2404,8 @@ channels:
     address: 'BMS/v1/{integration}/Value/GenericObject/{pointType}/{tagPath}'
     description: |
       Values published by integrations for GenericObject control points.
-      Subscribe to `genericObjectMetadata` first and read `integration` for the exact topic.
+      Subscribe to `BMS/v1/PUB/Metadata/GenericObject/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
 
       **MQTT wildcard examples**
 
@@ -1974,6 +2416,7 @@ channels:
       pointType:
         enum:
           - LiquidTemperatureSpRequest
+          - GenericPoint
         description: Integration-published GenericObject point type.
       tagPath:
         description: Must match the tagPath from the corresponding BMS metadata exactly.
@@ -2048,11 +2491,13 @@ channels:
   systemIntegrationValue:
     address: 'BMS/v1/{integration}/Value/System/{pointType}/{tagPath}'
     description: |
-      Values published by integrations for Heartbeat points.
+      Values published by integrations for System points (Integration heartbeats, Status, Available, and GenericPoint).
+      Subscribe to `BMS/v1/PUB/Metadata/System/#` and publish only when that metadata payload includes an `integration` field whose value matches the publishing integration identifier.
+      That matching metadata payload indicates the integration can publish values to this topic.
 
       **MQTT wildcard examples**
 
-      - All integration heartbeat values: `BMS/v1/+/Value/System/#`
+      - All integration System values: `BMS/v1/+/Value/System/#`
     parameters:
       integration:
         description: Integration identifier.
@@ -2060,6 +2505,9 @@ channels:
         enum:
           - HeartbeatTimestampIntegration
           - HeartbeatEchoIntegration
+          - Status
+          - Available
+          - GenericPoint
         description: Integration-published System point type.
       tagPath:
         description: Vendor-defined hierarchical tag path.
@@ -2136,6 +2584,14 @@ operations:
       - $ref: '#/channels/powerMeterMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for all PowerMeter points.
 
+  publishPowerMeterIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/powerMeterIntegrationValue'
+    messages:
+      - $ref: '#/channels/powerMeterIntegrationValue/messages/valueMessage'
+    description: Publish integration values for PowerMeter control points.
+
   receiveBESSValue:
     action: receive
     channel:
@@ -2153,6 +2609,14 @@ operations:
       - $ref: '#/channels/bessMetadata/messages/available'
       - $ref: '#/channels/bessMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for BESS points.
+
+  publishBESSIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/bessIntegrationValue'
+    messages:
+      - $ref: '#/channels/bessIntegrationValue/messages/valueMessage'
+    description: Publish integration values for BESS control points.
 
   receiveUPSValue:
     action: receive
@@ -2172,6 +2636,14 @@ operations:
       - $ref: '#/channels/upsMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for UPS points.
 
+  publishUPSIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/upsIntegrationValue'
+    messages:
+      - $ref: '#/channels/upsIntegrationValue/messages/valueMessage'
+    description: Publish integration values for UPS control points.
+
   receiveATSValue:
     action: receive
     channel:
@@ -2189,6 +2661,14 @@ operations:
       - $ref: '#/channels/atsMetadata/messages/available'
       - $ref: '#/channels/atsMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for ATS points.
+
+  publishATSIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/atsIntegrationValue'
+    messages:
+      - $ref: '#/channels/atsIntegrationValue/messages/valueMessage'
+    description: Publish integration values for ATS control points.
 
   receiveGeneratorValue:
     action: receive
@@ -2208,6 +2688,14 @@ operations:
       - $ref: '#/channels/generatorMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for Generator points.
 
+  publishGeneratorIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/generatorIntegrationValue'
+    messages:
+      - $ref: '#/channels/generatorIntegrationValue/messages/valueMessage'
+    description: Publish integration values for Generator control points.
+
   receiveShuntValue:
     action: receive
     channel:
@@ -2226,6 +2714,14 @@ operations:
       - $ref: '#/channels/shuntMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for Shunt points.
 
+  publishShuntIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/shuntIntegrationValue'
+    messages:
+      - $ref: '#/channels/shuntIntegrationValue/messages/valueMessage'
+    description: Publish integration values for Shunt control points.
+
   receiveBreakerValue:
     action: receive
     channel:
@@ -2243,6 +2739,14 @@ operations:
       - $ref: '#/channels/breakerMetadata/messages/available'
       - $ref: '#/channels/breakerMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for Breaker points.
+
+  publishBreakerIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/breakerIntegrationValue'
+    messages:
+      - $ref: '#/channels/breakerIntegrationValue/messages/valueMessage'
+    description: Publish integration values for Breaker control points.
 
   receiveCDUValue:
     action: receive
@@ -2317,6 +2821,14 @@ operations:
       - $ref: '#/channels/coolingTowerMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for CoolingTower points.
 
+  publishCoolingTowerIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/coolingTowerIntegrationValue'
+    messages:
+      - $ref: '#/channels/coolingTowerIntegrationValue/messages/valueMessage'
+    description: Publish integration values for CoolingTower control points.
+
   receiveHXValue:
     action: receive
     channel:
@@ -2348,6 +2860,14 @@ operations:
       - $ref: '#/channels/hxMetadata/messages/leakDetect'
       - $ref: '#/channels/hxMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for HX points.
+
+  publishHXIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/hxIntegrationValue'
+    messages:
+      - $ref: '#/channels/hxIntegrationValue/messages/valueMessage'
+    description: Publish integration values for HX control points.
 
   receiveCRAHValue:
     action: receive
@@ -2381,6 +2901,14 @@ operations:
       - $ref: '#/channels/crahMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for CRAH points.
 
+  publishCRAHIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/crahIntegrationValue'
+    messages:
+      - $ref: '#/channels/crahIntegrationValue/messages/valueMessage'
+    description: Publish integration values for CRAH control points.
+
   receiveCRACValue:
     action: receive
     channel:
@@ -2412,6 +2940,14 @@ operations:
       - $ref: '#/channels/cracMetadata/messages/leakDetect'
       - $ref: '#/channels/cracMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for CRAC points.
+
+  publishCRACIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/cracIntegrationValue'
+    messages:
+      - $ref: '#/channels/cracIntegrationValue/messages/valueMessage'
+    description: Publish integration values for CRAC control points.
 
   receiveAHUValue:
     action: receive
@@ -2445,6 +2981,14 @@ operations:
       - $ref: '#/channels/ahuMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for AHU points.
 
+  publishAHUIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/ahuIntegrationValue'
+    messages:
+      - $ref: '#/channels/ahuIntegrationValue/messages/valueMessage'
+    description: Publish integration values for AHU control points.
+
   receiveChillerValue:
     action: receive
     channel:
@@ -2477,6 +3021,14 @@ operations:
       - $ref: '#/channels/chillerMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for Chiller points.
 
+  publishChillerIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/chillerIntegrationValue'
+    messages:
+      - $ref: '#/channels/chillerIntegrationValue/messages/valueMessage'
+    description: Publish integration values for Chiller control points.
+
   receiveValveValue:
     action: receive
     channel:
@@ -2494,6 +3046,14 @@ operations:
       - $ref: '#/channels/valveMetadata/messages/available'
       - $ref: '#/channels/valveMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for Valve points.
+
+  publishValveIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/valveIntegrationValue'
+    messages:
+      - $ref: '#/channels/valveIntegrationValue/messages/valueMessage'
+    description: Publish integration values for Valve control points.
 
   receivePumpValue:
     action: receive
@@ -2513,6 +3073,14 @@ operations:
       - $ref: '#/channels/pumpMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for Pump points.
 
+  publishPumpIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/pumpIntegrationValue'
+    messages:
+      - $ref: '#/channels/pumpIntegrationValue/messages/valueMessage'
+    description: Publish integration values for Pump control points.
+
   receiveFanValue:
     action: receive
     channel:
@@ -2531,6 +3099,14 @@ operations:
       - $ref: '#/channels/fanMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for Fan points.
 
+  publishFanIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/fanIntegrationValue'
+    messages:
+      - $ref: '#/channels/fanIntegrationValue/messages/valueMessage'
+    description: Publish integration values for Fan control points.
+
   receiveDamperValue:
     action: receive
     channel:
@@ -2548,6 +3124,14 @@ operations:
       - $ref: '#/channels/damperMetadata/messages/available'
       - $ref: '#/channels/damperMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for Damper points.
+
+  publishDamperIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/damperIntegrationValue'
+    messages:
+      - $ref: '#/channels/damperIntegrationValue/messages/valueMessage'
+    description: Publish integration values for Damper control points.
 
   receiveSensorValue:
     action: receive
@@ -2577,6 +3161,14 @@ operations:
       - $ref: '#/channels/sensorMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for Sensor points.
 
+
+  publishSensorIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/sensorIntegrationValue'
+    messages:
+      - $ref: '#/channels/sensorIntegrationValue/messages/valueMessage'
+    description: Publish integration values for Sensor control points.
 
   receiveTankValue:
     action: receive
@@ -2609,6 +3201,14 @@ operations:
       - $ref: '#/channels/tankMetadata/messages/leakDetect'
       - $ref: '#/channels/tankMetadata/messages/genericPoint'
     description: Subscribe to BMS-published metadata for Tank points.
+
+  publishTankIntegrationValue:
+    action: send
+    channel:
+      $ref: '#/channels/tankIntegrationValue'
+    messages:
+      - $ref: '#/channels/tankIntegrationValue/messages/valueMessage'
+    description: Publish integration values for Tank control points.
 
   receiveGenericObjectValue:
     action: receive
@@ -2669,6 +3269,9 @@ operations:
       - $ref: '#/channels/systemMetadata/messages/heartbeatEchoBms'
       - $ref: '#/channels/systemMetadata/messages/heartbeatTimestampIntegration'
       - $ref: '#/channels/systemMetadata/messages/heartbeatEchoIntegration'
+      - $ref: '#/channels/systemMetadata/messages/status'
+      - $ref: '#/channels/systemMetadata/messages/available'
+      - $ref: '#/channels/systemMetadata/messages/genericPoint'
     description: Subscribe to System metadata for all System point types.
 
   publishSystemIntegrationValue:
@@ -4436,6 +5039,7 @@ components:
       description: Valid pointType values for Integration-published generic equipment points.
       enum:
         - LiquidTemperatureSpRequest
+        - GenericPoint
 
     EquipmentObjectType:
       type: string
@@ -4478,6 +5082,9 @@ components:
       enum:
         - HeartbeatTimestampIntegration
         - HeartbeatEchoIntegration
+        - Status
+        - Available
+        - GenericPoint
 
 
     # =========================================================================

--- a/schemas/asyncapi/bms/bms.yaml
+++ b/schemas/asyncapi/bms/bms.yaml
@@ -128,6 +128,16 @@ info:
 
         Naming convention: the `Bms`/`Integration` suffix indicates the publisher of the point. The party whose timestamp is being echoed is encoded in `objectId`, not in the point name.
 
+        All four heartbeat pointTypes require `objectName` and `objectId` in metadata to identify which System the heartbeat belongs to. By convention, an integration's `objectId` matches the same string used as its `integration` metadata field on its other points (so MEPAI1's System object has `objectId: "MEPAI1"`).
+
+        - **HeartbeatTimestampBms** — Publisher: BMS. The BMS publishes its own timestamp every 10 seconds. One instance globally. `objectId` identifies the BMS (e.g., `"BMS"`). `integration` field: not used.
+
+        - **HeartbeatTimestampIntegration** — Publisher: Integration. Each integration publishes its own timestamp every 10 seconds, one per integration. `objectId` identifies the integration publishing (e.g., `"MEPAI1"`). `integration` field: required (drives topic).
+
+        - **HeartbeatEchoBms** — Publisher: BMS. The BMS reads each integration's `HeartbeatTimestampIntegration` value and re-publishes it on this point type, allowing each integration to confirm round-trip. One instance per connected integration. `objectId` identifies the integration whose timestamp is being echoed (e.g., `"MEPAI1"`). `integration` field: not used.
+
+        - **HeartbeatEchoIntegration** — Publisher: Integration. Each integration reads the BMS's `HeartbeatTimestampBms` value and re-publishes it on this point type, allowing the BMS to confirm round-trip with that integration. One per connected integration. `objectId` identifies the BMS being echoed (e.g., `"BMS"`). `integration` field: required (drives topic).
+
       - **Rack**: A Rack is a special object type and has specific point types that can only be used with a Rack object type. Many integrations and MQTT Clients will only ingest data from the Rack object type. Other integrations will consider Rack data as the most important or interesting data in the AI Factory. Mechanical and Electrical design (and therefore BMS Data) at the rack is also more standardized than mechanical and electrical systems as you move out of the white space and to the gray space of the AI Factory. For these reasons, the point types associated with a Rack object type are generally more specific than any other object type, making ingesting and understanding rack data more straight-forward.
 
       - **PowerMeter**: A PowerMeter is a special object type and has specific point types that can only be used with a PowerMeter object type. PowerMeter point types contain the metadata needed to understand electrical power path. This data is used by integrations / MQTT Clients for power management strategies.

--- a/schemas/asyncapi/bms/bms.yaml
+++ b/schemas/asyncapi/bms/bms.yaml
@@ -116,17 +116,7 @@ info:
 
       - **System**: A System can be the BMS or an Integration to the BMS. Heartbeat points and system-to-system communication point types are typically defined inside of a System object type. System Heartbeat point types are expected to operate as follows. An integration may choose to use the Echo points or not.
 
-        All four heartbeat pointTypes require `objectName` and `objectId` in metadata to identify which System the heartbeat belongs to. By convention, an integration's `objectId` matches the same string used as its `integration` metadata field on its other points (so MEPAI1's System object has `objectId: "MEPAI1"`).
-
-        - **HeartbeatTimestampBms** — Publisher: BMS. The BMS publishes its own timestamp every 10 seconds. One instance globally. `objectId` identifies the BMS (e.g., `"BMS"`). `integration` field: not used.
-
-        - **HeartbeatTimestampIntegration** — Publisher: Integration. Each integration publishes its own timestamp every 10 seconds, one per integration. `objectId` identifies the integration publishing (e.g., `"MEPAI1"`). `integration` field: required (drives topic).
-
-        - **HeartbeatEchoBms** — Publisher: BMS. The BMS reads each integration's `HeartbeatTimestampIntegration` value and re-publishes it on this point type, allowing each integration to confirm round-trip. One instance per connected integration. `objectId` identifies the integration whose timestamp is being echoed (e.g., `"MEPAI1"`). `integration` field: not used.
-
-        - **HeartbeatEchoIntegration** — Publisher: Integration. Each integration reads the BMS's `HeartbeatTimestampBms` value and re-publishes it on this point type, allowing the BMS to confirm round-trip with that integration. One per connected integration. `objectId` identifies the BMS being echoed (e.g., `"BMS"`). `integration` field: required (drives topic).
-
-        Naming convention: the `Bms`/`Integration` suffix indicates the publisher of the point. The party whose timestamp is being echoed is encoded in `objectId`, not in the point name.
+        Naming convention: the `BMS`/`Integration` suffix indicates the publisher of the point.
 
         All four heartbeat pointTypes require `objectName` and `objectId` in metadata to identify which System the heartbeat belongs to. By convention, an integration's `objectId` matches the same string used as its `integration` metadata field on its other points (so MEPAI1's System object has `objectId: "MEPAI1"`).
 


### PR DESCRIPTION


  ## Description

  This PR closes a gap between the BMS rules sheet and the AsyncAPI schema for integration-published value topics.

  The schema previously allowed integrations to publish only a narrow set of value point types. It did not expose integration value channels for `GenericPoint` across most object types, and it did not allow
  integrations to publish `System/Status` or `System/Available` values.

 - Adds integration value channels for GenericPoint on non-Rack BMS object types that did not previously have integration write channels.
  - Adds GenericPoint to existing cduIntegrationValue and genericObjectIntegrationValue.
  - Adds Status, Available, and GenericPoint to systemIntegrationValue, so integrations can publish:
      - BMS/v1/{integration}/Value/System/Status/{tagPath}
      - BMS/v1/{integration}/Value/System/Available/{tagPath}
      - BMS/v1/{integration}/Value/System/GenericPoint/{tagPath}

  - Leaves Rack unchanged: no GenericPoint integration write for Rack.
  - Leaves metadata unchanged: BMS remains the sole metadata publisher.
  - Regenerates BMS docs and adds Fern nav entries for the new integration value pages.


  ## Validation

  - `python3 scripts/generate_asyncapi_docs.py --spec bms`
  - `./tools/check-docs-mdx`
  - `fern check`
  - Verified `schemas/asyncapi/bms/bms.yaml` now has 23 integration value channels
  - Verified Rack integration point types remain unchanged

  Not run locally:
  - `make check` because local `addlicense` dependency is missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Integration‑Value MQTT docs covering many equipment types (PowerMeter, BESS, UPS, ATS, Generator, Shunt, Breaker, CoolingTower, HX, CRAH, CRAC, AHU, Chiller, Valve, Pump, Fan, Damper, Sensor, Tank, Rack, CDU, GenericObject) and updated navigation.
  * Standardized topic naming and metadata‑gated publishing guidance (publish only when metadata’s integration matches).
  * Consolidated JSON point‑value schema (value, timestamp, quality) with examples; expanded System/equipment point types (Status, Available, GenericPoint) and added System metadata sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->