### PR TITLE
fix(local): wait for nats stream readiness

### DIFF
--- a/local/nats/skaffold.releases.yaml
+++ b/local/nats/skaffold.releases.yaml
@@ -10,6 +10,7 @@ metadata:
   chartPath: ../../deploy/nats-event-bus
   namespace: event-bus
   createNamespace: true
+  wait: true
   setValues:
     auth-callout.image.repository: localhost:5001/auth-callout
     auth-callout.image.tag: local


### PR DESCRIPTION
## Summary
- Set `wait: true` on the local NATS Helm release base so Skaffold invokes Helm with `--wait`.
- This makes Helm wait for the JetStream `Stream` CRs rendered by the NATS event-bus chart before the local deploy is considered complete.

## Evidence
- Negative local repro: temporarily set MQTT Stream replicas to `99`; Helm `--wait` failed the Skaffold deploy on `Stream/event-bus/mqtt-* not ready` with `context deadline exceeded`.
- Skaffold custom-resource selectors were tested and rejected: `Stream`-only selectors exited successfully while Streams were still `Errored`; Gateway selectors produced false waits in unrelated namespaces.

## Validation
- `make check`
- `helm lint deploy/nats-event-bus -f local/nats/k8s/local-dev-values.yaml -f local/nats/k8s/cpc/values.yaml -f local/nats/k8s/cpc/cpc-2.yaml`
- `skaffold run -f local/nats/skaffold.yaml -m nats-cpc-2 --cleanup=false --label=skaffold.dev/run-id=local-e2e-restore`
- `make -C local skaffold-run`
- `kubectl get streams -A` on `kind-csc`, `kind-cpc-1`, and `kind-cpc-2`: all MQTT Streams `Ready`
- Containerized functional suite on Docker `kind` network: pass
- Containerized performance smoke on Docker `kind` network: 12 passed, 0 failed

Note: `make -C local test-dev` from this macOS host still fails before MQTT assertions with `i/o timeout` to the MetalLB IPs; the same tests pass from a container attached to the Kind network.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to ensure proper completion verification before proceeding to the next step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->