### PR TITLE
fix(local): addlicense prereq

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,24 @@ DSX Exchange provides the repository pieces needed to describe, deploy, and vali
 
 The event bus itself is schema agnostic. Schemas document externally visible contracts; NATS and the auth callout enforce routing, federation, and authorization behavior.
 
+## Requirements
+
+- OS: Linux or macOS with Docker support.
+- Tools: `go`, `make`, `helm`, `kubectl`, `kind`, `docker`, `jq`, `yq`, `cfssl`, `nsc`, `addlicense`.
+- Kubernetes: local Kind clusters for e2e testing.
+- Runtime: Go modules declare their own supported Go versions.
+
+GPU drivers are not required.
+
 ## Getting Started
 
-Clone the repository and run the local validation checks:
+Clone the repository, install the local e2e prerequisites, and run the local
+validation checks:
 
 ```bash
 git clone https://github.com/NVIDIA/dsx-exchange.git
 cd dsx-exchange
+make install-e2e-prereqs
 make test
 ```
 
@@ -34,15 +45,6 @@ Publish looping dummy BMS data into the local CSC MQTT broker:
 ```bash
 make dummy-bms
 ```
-
-## Requirements
-
-- OS: Linux or macOS with Docker support.
-- Tools: `go`, `make`, `helm`, `kubectl`, `kind`, `docker`, `jq`, `yq`, `cfssl`, `nsc`, `addlicense`.
-- Kubernetes: local Kind clusters for e2e testing.
-- Runtime: Go modules declare their own supported Go versions.
-
-GPU drivers are not required.
 
 ## Usage
 

--- a/local/README.md
+++ b/local/README.md
@@ -24,6 +24,7 @@ warns when its version differs from the expected version:
 - nsc v2.14.0
 - nk v0.4.15
 - yq v4.53.2
+- addlicense v1.2.0
 
 ### MacOS Tweaks
 

--- a/local/infra/scripts/install-e2e-prereqs.sh
+++ b/local/infra/scripts/install-e2e-prereqs.sh
@@ -12,6 +12,7 @@ CFSSL_VERSION="${CFSSL_VERSION:-v1.6.5}"
 NSC_VERSION="${NSC_VERSION:-v2.14.0}"
 NKEYS_VERSION="${NKEYS_VERSION:-v0.4.15}"
 YQ_VERSION="${YQ_VERSION:-v4.53.2}"
+ADDLICENSE_VERSION="${ADDLICENSE_VERSION:-v1.2.0}"
 
 if [ -z "${E2E_PREREQS_BIN:-}" ]; then
   go_bin="$(go env GOBIN 2>/dev/null || true)"
@@ -171,6 +172,7 @@ install_go_tool cfssljson github.com/cloudflare/cfssl/cmd/cfssljson "${CFSSL_VER
 install_go_tool nsc github.com/nats-io/nsc/v2 "${NSC_VERSION}" --version
 install_go_tool nk github.com/nats-io/nkeys/nk "${NKEYS_VERSION}"
 install_go_tool yq github.com/mikefarah/yq/v4 "${YQ_VERSION}" --version
+install_go_tool addlicense github.com/google/addlicense "${ADDLICENSE_VERSION}"
 
 kind version
 kubectl version --client=true
@@ -180,3 +182,4 @@ cfssl version
 nsc --version
 nk -v
 yq --version
+addlicense --help >/dev/null 2>&1


### PR DESCRIPTION
## Description

Adds addlicense to prerequisite checks, and moves requirements up before the getting started readme header.

Closes #74

## Validation

List the commands you ran.

```bash
make install-e2e-prereqs
```

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/dsx-exchange/blob/main/CONTRIBUTING.md).
- [x] Documentation updated, if needed.
- [x] Tests or validation added/updated, if needed.
- [x] License headers are present on applicable source files.
- [x] Third-party license inventory updated, if dependencies changed.
- [x] Security-sensitive changes were reviewed privately before public disclosure.
- [x] My commits are signed off (`git commit -s`) per the DCO.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized README structure with Requirements section appearing before Getting Started for improved clarity
  * Enhanced Getting Started workflow by integrating e2e prerequisite installation steps into the initial setup sequence

* **Chores**
  * Added addlicense v1.2.0 tool to development environment prerequisites

<!-- end of auto-generated comment: release notes by coderabbit.ai -->