### PR TITLE
feat(auth-callout): configure jwt algs

### DIFF
--- a/auth-callout/README.md
+++ b/auth-callout/README.md
@@ -33,6 +33,9 @@ jwks:
   url: "https://keycloak/realms/master/protocol/openid-connect/certs"
   issuer: "https://keycloak/realms/master"
   audience: "dsx-exchange"
+  signing-algorithms:
+    - RS256
+    - ES256
 
 mtls:
   ca-path: "/etc/ssl/certs/ca.crt"

--- a/auth-callout/api/env.example
+++ b/auth-callout/api/env.example
@@ -9,3 +9,4 @@ NATS_URL=nats://nats:4222
 JWKS_URL=http://keycloak.127-0-0-1.nip.io:8080/realms/auth-callout/protocol/openid-connect/certs
 JWKS_ISSUER=http://keycloak.127-0-0-1.nip.io:8080/realms/auth-callout
 JWKS_AUDIENCE=dsx-exchange
+JWKS_SIGNING_ALGORITHMS=RS256

--- a/auth-callout/deploy/README.md
+++ b/auth-callout/deploy/README.md
@@ -84,6 +84,9 @@ serviceConfig:
     url: "https://keycloak/realms/master/protocol/openid-connect/certs"
     issuer: "https://keycloak/realms/master"
     audience: "dsx-exchange"
+    signing-algorithms:
+      - RS256
+      - ES256
 ```
 
 ### mTLS Configuration

--- a/auth-callout/env.example
+++ b/auth-callout/env.example
@@ -9,6 +9,7 @@ NATS_URL=nats://nats:4222
 JWKS_URL=http://keycloak.127-0-0-1.nip.io:8080/realms/auth-callout/protocol/openid-connect/certs
 JWKS_ISSUER=http://keycloak.127-0-0-1.nip.io:8080/realms/auth-callout
 JWKS_AUDIENCE=dsx-exchange
+JWKS_SIGNING_ALGORITHMS=RS256
 
 # NATS keys are secrets and must come from Vault or generated local files.
 # Generate development values with scripts/devspace-get-key.sh or nsc.

--- a/auth-callout/src/cmd/auth_callout/config/defaults.yaml
+++ b/auth-callout/src/cmd/auth_callout/config/defaults.yaml
@@ -16,6 +16,8 @@ jwks:
   url: ""            # JWKS endpoint URL
   issuer: ""         # Expected JWT issuer
   audience: ""       # Expected JWT audience
+  signing-algorithms:
+    - RS256          # Allowed JWT signing algorithms
 
 # mTLS configuration
 mtls:

--- a/auth-callout/src/cmd/auth_callout/main_test.go
+++ b/auth-callout/src/cmd/auth_callout/main_test.go
@@ -43,6 +43,28 @@ func TestRunServerDoesNotLogConfiguredNATSSeeds(t *testing.T) {
 	}
 }
 
+func TestDefaultConfigIncludesJWKSSigningAlgorithms(t *testing.T) {
+	// Load overlays env and config-file sources after defaultConfigYAML; clear
+	// those inputs so this test only proves the embedded app defaults.
+	t.Setenv("AUTH_CALLOUT_CONFIG", "")
+	t.Setenv("AUTH_CALLOUT_CONFIG_FILE", "")
+	t.Setenv("AUTH_CALLOUT_HOT_CONFIG", "")
+	t.Setenv("AUTH_CALLOUT_JWKS_SIGNING_ALGORITHMS", "")
+	t.Setenv("JWKS_SIGNING_ALGORITHMS", "")
+
+	manager := appconfig.New(defaultConfigYAML)
+	require.NoError(t, manager.Load())
+
+	type jwksConfig struct {
+		JWKS struct {
+			SigningAlgorithms []string `koanf:"signing-algorithms"`
+		} `koanf:"jwks"`
+	}
+	var config jwksConfig
+	require.NoError(t, manager.Unmarshal(&config))
+	require.Equal(t, []string{"RS256"}, config.JWKS.SigningAlgorithms)
+}
+
 func captureStderr(t *testing.T, fn func()) string {
 	t.Helper()
 

--- a/auth-callout/src/internal/appconfig/manager.go
+++ b/auth-callout/src/internal/appconfig/manager.go
@@ -108,6 +108,7 @@ func applyAliases(k *koanf.Koanf) {
 	setString(k, "jwks.url", "JWKS_URL", envPrefix+"JWKS_URL")
 	setString(k, "jwks.issuer", "JWKS_ISSUER", envPrefix+"JWKS_ISSUER")
 	setString(k, "jwks.audience", "JWKS_AUDIENCE", envPrefix+"JWKS_AUDIENCE")
+	setStringSlice(k, "jwks.signing-algorithms", "JWKS_SIGNING_ALGORITHMS", envPrefix+"JWKS_SIGNING_ALGORITHMS")
 	setString(k, "mtls.ca-path", "MTLS_CA_PATH", envPrefix+"MTLS_CA_PATH")
 	setString(k, "permissions.file", "PERMISSIONS_FILE", envPrefix+"PERMISSIONS_FILE")
 	setString(k, "observability.telemetry.service-name", envPrefix+"SERVICE_NAME")
@@ -117,6 +118,12 @@ func applyAliases(k *koanf.Koanf) {
 func setString(k *koanf.Koanf, key string, names ...string) {
 	if value := envValue(names...); value != "" {
 		k.Set(key, value)
+	}
+}
+
+func setStringSlice(k *koanf.Koanf, key string, names ...string) {
+	if value := envValue(names...); value != "" {
+		k.Set(key, strings.Split(value, ","))
 	}
 }
 

--- a/auth-callout/src/internal/appconfig/manager_test.go
+++ b/auth-callout/src/internal/appconfig/manager_test.go
@@ -38,6 +38,22 @@ nats:
 	require.Equal(t, "SXFAKE", config.NATS.XKeySeed)
 }
 
+func TestLoadAllowsJWKSAlgorithmsInEnvironment(t *testing.T) {
+	t.Setenv("AUTH_CALLOUT_JWKS_SIGNING_ALGORITHMS", "RS256,ES256")
+
+	manager := New("")
+	require.NoError(t, manager.Load())
+
+	type jwksConfig struct {
+		JWKS struct {
+			SigningAlgorithms []string `koanf:"signing-algorithms"`
+		} `koanf:"jwks"`
+	}
+	var config jwksConfig
+	require.NoError(t, manager.Unmarshal(&config))
+	require.Equal(t, []string{"RS256", "ES256"}, config.JWKS.SigningAlgorithms)
+}
+
 func writeConfigFile(t *testing.T, name, content string) string {
 	t.Helper()
 

--- a/auth-callout/src/internal/auth/auth_test.go
+++ b/auth-callout/src/internal/auth/auth_test.go
@@ -5,6 +5,8 @@ package auth
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -35,6 +37,51 @@ const testServiceName = "auth-callout-test"
 func testLogger() *otelzap.Logger {
 	zapLogger, _ := zap.NewDevelopment()
 	return otelzap.New(zapLogger)
+}
+
+func TestValidateOAuth2SigningAlgorithms(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     []string
+		expectErr string
+	}{
+		{
+			name:      "rejects missing algorithms",
+			expectErr: "OAuth2 signing algorithms are required",
+		},
+		{
+			name:  "accepts configured algorithms",
+			input: []string{"RS256", "ES256", "RS256"},
+		},
+		{
+			name:      "rejects algorithms with whitespace",
+			input:     []string{"RS256", " ES256"},
+			expectErr: `unsupported OAuth2 signing algorithm " ES256"`,
+		},
+		{
+			name:      "rejects empty algorithm",
+			input:     []string{"RS256", ""},
+			expectErr: `unsupported OAuth2 signing algorithm ""`,
+		},
+		{
+			name:      "rejects unsupported algorithm",
+			input:     []string{"HS256"},
+			expectErr: `unsupported OAuth2 signing algorithm "HS256"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOAuth2SigningAlgorithms(tt.input)
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
 }
 
 // TestOAuth2Authentication tests OAuth2/JWKS authentication with mock server
@@ -88,6 +135,7 @@ func TestOAuth2Authentication(t *testing.T) {
 		jwksServer.URL,
 		"https://auth.example.com/",
 		"test-audience",
+		[]string{gojwt.SigningMethodRS256.Alg()},
 		pm,
 		testLogger(),
 		testServiceName,
@@ -287,6 +335,7 @@ func TestOAuth2RejectsUnexpectedSigningMethod(t *testing.T) {
 		jwksServer.URL,
 		"https://auth.example.com/",
 		"test-audience",
+		[]string{gojwt.SigningMethodRS256.Alg()},
 		pm,
 		testLogger(),
 		testServiceName,
@@ -308,6 +357,68 @@ func TestOAuth2RejectsUnexpectedSigningMethod(t *testing.T) {
 	_, err = oauth2Auth.Authenticate(context.Background(), tokenString)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "signing method HS256 is invalid")
+}
+
+func TestOAuth2AllowsConfiguredES256SigningMethod(t *testing.T) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	jwkSet := jwkset.NewMemoryStorage()
+	jwk, err := jwkset.NewJWKFromKey(privateKey, jwkset.JWKOptions{
+		Metadata: jwkset.JWKMetadataOptions{
+			KID: "test-key-1",
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, jwkSet.KeyWrite(context.Background(), jwk))
+
+	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		jwks, err := jwkSet.JSONPublic(context.Background())
+		if err != nil {
+			http.Error(w, "Failed to get JWKS", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write(jwks); err != nil {
+			http.Error(w, "Failed to write JWKS", http.StatusInternalServerError)
+		}
+	}))
+	defer jwksServer.Close()
+
+	permFile := createTestPermissionsFile(t)
+	defer os.Remove(permFile)
+
+	pm, err := config.NewPermissionsManager(permFile, testLogger())
+	require.NoError(t, err)
+	defer pm.Close()
+
+	oauth2Auth, err := NewOAuth2Authenticator(
+		jwksServer.URL,
+		"https://auth.example.com/",
+		"test-audience",
+		[]string{gojwt.SigningMethodRS256.Alg(), gojwt.SigningMethodES256.Alg()},
+		pm,
+		testLogger(),
+		testServiceName,
+	)
+	require.NoError(t, err)
+	defer oauth2Auth.Close()
+
+	token := gojwt.NewWithClaims(gojwt.SigningMethodES256, gojwt.MapClaims{
+		"iss":   "https://auth.example.com/",
+		"sub":   "user@example.com",
+		"aud":   "test-audience",
+		"exp":   time.Now().Add(1 * time.Hour).Unix(),
+		"scope": "mqtt",
+	})
+	token.Header["kid"] = "test-key-1"
+	tokenString, err := token.SignedString(privateKey)
+	require.NoError(t, err)
+
+	profile, err := oauth2Auth.Authenticate(context.Background(), tokenString)
+	require.NoError(t, err)
+	require.NotNil(t, profile)
+	assert.Equal(t, "APP1", profile.Account)
 }
 
 // TestOAuth2RequiredScope tests per-client required scope validation
@@ -382,6 +493,7 @@ func TestOAuth2RequiredScope(t *testing.T) {
 		jwksServer.URL,
 		"https://auth.example.com/",
 		"test-audience",
+		[]string{gojwt.SigningMethodRS256.Alg()},
 		pm,
 		testLogger(),
 		testServiceName,

--- a/auth-callout/src/internal/auth/oauth2.go
+++ b/auth-callout/src/internal/auth/oauth2.go
@@ -23,23 +23,39 @@ import (
 
 // OAuth2Authenticator handles OAuth2/JWKS-based authentication
 type OAuth2Authenticator struct {
-	jwks        keyfunc.Keyfunc
-	pm          *config.PermissionsManager
-	issuer      string
-	audience    string
-	jwksURL     string
-	logger      *otelzap.Logger
-	serviceName string
-	cancel      context.CancelFunc
+	jwks              keyfunc.Keyfunc
+	pm                *config.PermissionsManager
+	issuer            string
+	audience          string
+	signingAlgorithms []string
+	logger            *otelzap.Logger
+	serviceName       string
+	cancel            context.CancelFunc
+}
+
+var supportedOAuth2SigningAlgorithms = map[string]struct{}{
+	jwt.SigningMethodRS256.Alg(): {},
+	jwt.SigningMethodRS384.Alg(): {},
+	jwt.SigningMethodRS512.Alg(): {},
+	jwt.SigningMethodES256.Alg(): {},
+	jwt.SigningMethodES384.Alg(): {},
+	jwt.SigningMethodES512.Alg(): {},
+	jwt.SigningMethodPS256.Alg(): {},
+	jwt.SigningMethodPS384.Alg(): {},
+	jwt.SigningMethodPS512.Alg(): {},
+	jwt.SigningMethodEdDSA.Alg(): {},
 }
 
 // NewOAuth2Authenticator creates a new OAuth2 authenticator
-func NewOAuth2Authenticator(jwksURL string, issuer string, audience string, pm *config.PermissionsManager, logger *otelzap.Logger, serviceName string) (*OAuth2Authenticator, error) {
+func NewOAuth2Authenticator(jwksURL string, issuer string, audience string, signingAlgorithms []string, pm *config.PermissionsManager, logger *otelzap.Logger, serviceName string) (*OAuth2Authenticator, error) {
 	if issuer == "" {
 		return nil, fmt.Errorf("OAuth2 issuer is required")
 	}
 	if audience == "" {
 		return nil, fmt.Errorf("OAuth2 audience is required")
+	}
+	if err := validateOAuth2SigningAlgorithms(signingAlgorithms); err != nil {
+		return nil, err
 	}
 
 	// Create JWKS client with automatic refresh - context controls lifecycle
@@ -50,18 +66,34 @@ func NewOAuth2Authenticator(jwksURL string, issuer string, audience string, pm *
 		return nil, fmt.Errorf("failed to create JWKS client: %w", err)
 	}
 
-	logger.Info("OAuth2 authenticator initialized", zap.String("jwks_url", jwksURL))
+	logger.Info("OAuth2 authenticator initialized",
+		zap.String("jwks_url", jwksURL),
+		zap.Strings("signing_algorithms", signingAlgorithms),
+	)
 
 	return &OAuth2Authenticator{
-		jwks:        k,
-		pm:          pm,
-		issuer:      issuer,
-		audience:    audience,
-		jwksURL:     jwksURL,
-		logger:      logger,
-		serviceName: serviceName,
-		cancel:      cancel,
+		jwks:              k,
+		pm:                pm,
+		issuer:            issuer,
+		audience:          audience,
+		signingAlgorithms: signingAlgorithms,
+		logger:            logger,
+		serviceName:       serviceName,
+		cancel:            cancel,
 	}, nil
+}
+
+func validateOAuth2SigningAlgorithms(configured []string) error {
+	if len(configured) == 0 {
+		return fmt.Errorf("OAuth2 signing algorithms are required")
+	}
+
+	for _, algorithm := range configured {
+		if _, ok := supportedOAuth2SigningAlgorithms[algorithm]; !ok {
+			return fmt.Errorf("unsupported OAuth2 signing algorithm %q", algorithm)
+		}
+	}
+	return nil
 }
 
 // CanAuthenticate checks if OAuth2 credentials are present
@@ -91,7 +123,7 @@ func (o *OAuth2Authenticator) Authenticate(ctx context.Context, token string) (*
 		token,
 		&Claims{},
 		o.jwks.Keyfunc,
-		jwt.WithValidMethods([]string{jwt.SigningMethodRS256.Alg()}),
+		jwt.WithValidMethods(o.signingAlgorithms),
 		jwt.WithExpirationRequired(),
 		jwt.WithIssuer(o.issuer),
 		jwt.WithAudience(o.audience),

--- a/auth-callout/src/internal/service/service.go
+++ b/auth-callout/src/internal/service/service.go
@@ -81,9 +81,10 @@ type NATSConfig struct {
 
 // JWKSConfig contains OAuth2/JWKS configuration
 type JWKSConfig struct {
-	URL      string `koanf:"url"`
-	Issuer   string `koanf:"issuer"`
-	Audience string `koanf:"audience"`
+	URL               string   `koanf:"url"`
+	Issuer            string   `koanf:"issuer"`
+	Audience          string   `koanf:"audience"`
+	SigningAlgorithms []string `koanf:"signing-algorithms"`
 }
 
 // MTLSConfig contains mTLS configuration
@@ -138,7 +139,7 @@ func New(config ServiceConfig, logger *otelzap.Logger) *Service {
 
 	// OAuth2 authenticator
 	if config.JWKS.URL != "" {
-		oauth2Auth, err := auth.NewOAuth2Authenticator(config.JWKS.URL, config.JWKS.Issuer, config.JWKS.Audience, pm, logger, serviceName)
+		oauth2Auth, err := auth.NewOAuth2Authenticator(config.JWKS.URL, config.JWKS.Issuer, config.JWKS.Audience, config.JWKS.SigningAlgorithms, pm, logger, serviceName)
 		if err != nil {
 			logger.Fatal("error initializing OAuth2 authenticator", zap.Error(err))
 		}


### PR DESCRIPTION
## Description

Adds configurable OAuth2 JWT signing algorithms for the auth-callout service.
The default app config remains `RS256`, while file or env config can opt into
additional supported asymmetric algorithms such as `ES256`.

Closes #77.

## Validation

```bash
git diff --check
cd auth-callout && go test -count=1 ./...
make check
```

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/dsx-exchange/blob/main/CONTRIBUTING.md).
- [x] Documentation updated, if needed.
- [x] Tests or validation added/updated, if needed.
- [x] License headers are present on applicable source files.
- [x] Third-party license inventory updated, if dependencies changed.
- [x] Security-sensitive changes were reviewed privately before public disclosure. (N/A: feature configuration change, no vulnerability disclosure)
- [x] My commits are signed off (`git commit -s`) per the DCO.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configurable JWT signing algorithms. The service now allows you to specify which signing algorithms are accepted for JWT validation via environment variables or configuration files, supporting multiple algorithms like RS256 and ES256.

* **Documentation**
  * Updated configuration examples and templates to document the new signing-algorithms option.

* **Tests**
  * Added comprehensive test coverage for signing algorithm validation and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->