### PR TITLE
fix(local): cap keycloak jvm heap and raise nats helm wait timeout

### DIFF
--- a/local/infra/keycloak/keycloak.yaml
+++ b/local/infra/keycloak/keycloak.yaml
@@ -18,10 +18,10 @@ spec:
   resources:
     requests:
       cpu: "100m"
-      memory: "550Mi"
+      memory: "1Gi"
     limits:
       cpu: "1000m"
-      memory: "550Mi"
+      memory: "1536Mi"
   unsupported:
     podTemplate:
       spec:
@@ -35,6 +35,13 @@ spec:
               - "--verbose"
               - "start"
               - "--import-realm"
+            env:
+              # Constrain the JVM heap so heap + non-heap RSS fits inside the
+              # container memory limit. Without this, Quarkus defaults to
+              # MaxRAMPercentage=70%, and heap + metaspace/GC/buffers exceed the
+              # limit and the pod is OOMKilled during the build phase.
+              - name: JAVA_OPTS_KC_HEAP
+                value: "-Xms256m -Xmx768m"
             volumeMounts:
               - name: realm-import
                 mountPath: /opt/keycloak/data/import

--- a/local/nats/skaffold.releases.yaml
+++ b/local/nats/skaffold.releases.yaml
@@ -32,6 +32,10 @@ deploy:
   tolerateFailuresUntilDeadline: true
   helm:
     flags:
+      # Helm's default --wait timeout is 5m; the mTLS NATS cluster can take
+      # longer to become ready on slower/loaded machines, so give it headroom.
+      upgrade:
+        - --timeout=15m
       depBuild:
         - --repository-config=local/helm/repositories.yaml
     releases:
@@ -61,6 +65,10 @@ deploy:
   tolerateFailuresUntilDeadline: true
   helm:
     flags:
+      # Helm's default --wait timeout is 5m; the mTLS NATS cluster can take
+      # longer to become ready on slower/loaded machines, so give it headroom.
+      upgrade:
+        - --timeout=15m
       depBuild:
         - --repository-config=local/helm/repositories.yaml
     releases:
@@ -91,6 +99,10 @@ deploy:
   tolerateFailuresUntilDeadline: true
   helm:
     flags:
+      # Helm's default --wait timeout is 5m; the mTLS NATS cluster can take
+      # longer to become ready on slower/loaded machines, so give it headroom.
+      upgrade:
+        - --timeout=15m
       depBuild:
         - --repository-config=local/helm/repositories.yaml
     releases:


### PR DESCRIPTION
## Summary

Two fixes to the local Kind e2e stack (`make test`) that were preventing it from completing:

- **Keycloak OOMKill crashloop.** With no JVM heap settings, Quarkus defaults to `MaxRAMPercentage=70%`, so heap + non-heap RSS (metaspace, GC, buffers) exceeded the container memory limit and the pod was OOMKilled during its build phase — regardless of machine speed. Constrain the heap via `JAVA_OPTS_KC_HEAP=-Xms256m -Xmx768m` and bump the limit to 1.5Gi for headroom. Keycloak now reaches Ready in ~30s.
- **NATS deploy timeout.** `nats-event-bus` is deployed with `wait: true`, but skaffold relied on Helm's default 5-minute `--wait` timeout. The mTLS NATS cluster can take longer to become ready on slower/loaded machines, producing `context deadline exceeded` even though the release ultimately deploys. Raise the upgrade `--timeout` to 15m on all three cluster configs (csc, cpc-1, cpc-2).

## Testing

Full `make test` (3-cluster Kind e2e incl. federation perf tests) passes end-to-end with these changes:

```
Test Summary: 12 passed, 0 failed out of 12 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Keycloak memory configuration to improve stability and prevent resource constraints during operation.
  * Extended deployment timeout for NATS services to provide additional headroom during cluster initialization and upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->