### PR TITLE
docs: add developer preview banner

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -13,6 +13,9 @@ instances:
 
 title: DSX Exchange
 
+announcement:
+  message: "🔔 DSX Exchange is a <strong>developer preview</strong>. APIs and behavior may change without notice."
+
 #==============================================================================
 # Content navigation from here down
 #==============================================================================


### PR DESCRIPTION
Add a banner to the docs letting readers know this is a developer preview, subject to change without notice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a developer-preview announcement banner to the documentation interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->