### PR TITLE
[codex] repair Fern validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,17 @@ jobs:
           ignore: ".git/**,**/*.md,**/*.png,**/*.sum,**/go.mod,**/tmp/**,**/vendor/**,auth-callout/vault-agent/templates/**,docs/schema-viewer/**,LICENSE,THIRD_PARTY_LICENSES*"
           go-version: "1.25.5"
 
+  fern-check:
+    name: Fern Check
+    runs-on: linux-amd64-cpu4
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm install -g fern-api
+      - run: fern check
+
   go-lint:
     name: Go Lint (auth-callout)
     runs-on: linux-amd64-cpu4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-      - run: npm install -g fern-api
+      - run: npm install -g fern-api@5.65.2
       - run: fern check
 
   go-lint:

--- a/docs/stateless-async-bus.md
+++ b/docs/stateless-async-bus.md
@@ -233,4 +233,4 @@ async state stream without making the bus part of the synchronous request path.
 - [BMS Integration](bms-integration.md)
 - [BMS Event Bus Schema](schema-bms.mdx)
 - [NICo Host State Schema](schema-nico.mdx)
-- [Power Management Schema](schema-power-management.mdx)
+- [Power Management Schema](schema-dsx-flex.mdx)


### PR DESCRIPTION
## Summary
- repair the stale Power Management schema link
- run Fern validation in the primary CI workflow

## Root cause
The stateless async guide still linked to the pre-rename schema page. Fern caught it only after merge.

## Validation
- `npm exec --yes --package=fern-api fern check`
- `./tools/check-docs-mdx`
- `actionlint -ignore 'label \".+\" is unknown' .github/workflows/ci.yml .github/workflows/fern-docs-ci.yml`\n- `make check`\n\nSigned-off-by and PGP-signed commit: `5cb0add`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new automated CI check to validate the project’s API specifications during builds.
* **Documentation**
  * Updated a documentation “Related Docs” link to point to the correct schema reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->