### PR TITLE
fix: (docs) DSX Flex left-nav rename

### DIFF
--- a/docs/pre-deployment.md
+++ b/docs/pre-deployment.md
@@ -316,9 +316,9 @@ Gateway listener names must match the `sectionName` in the Helm `gateway.routes`
 
 ## External References
 
-- Vault KV Secret Engine: https://developer.hashicorp.com/vault/docs/secrets/kv
-- Vault PKI Secret Engine: https://developer.hashicorp.com/vault/docs/secrets/pki
-- Vault Secrets Operator: https://developer.hashicorp.com/vault/docs/deploy/kubernetes/vso
-- cert-manager Vault Issuer: https://cert-manager.io/docs/configuration/vault/
-- NATS NKey Auth: https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth
-- NATS Auth Callout: https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_callout
+- [Vault KV Secret Engine](https://developer.hashicorp.com/vault/docs/secrets/kv)
+- [Vault PKI Secret Engine](https://developer.hashicorp.com/vault/docs/secrets/pki)
+- [Vault Secrets Operator](https://developer.hashicorp.com/vault/docs/deploy/kubernetes/vso)
+- [cert-manager Vault Issuer](https://cert-manager.io/docs/configuration/vault/)
+- [NATS NKey Auth](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth)
+- [NATS Auth Callout](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_callout)

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -334,7 +334,7 @@ navigation:
           - page: Schemas
             path: ../docs/schema-bms-schemas.mdx
             slug: schemas
-      - section: Power Management
+      - section: DSX Flex
         contents:
           - page: Overview
             path: ../docs/schema-dsx-flex.mdx


### PR DESCRIPTION
## Description

Renaming the Schema > Power Management entry in the left nav to Schema > DSX Flex. This is partly because we _should_ rename it, and also partly to trigger a rebuild/redeployment of the public Fern docs.

## Validation

All clear:

```bash
tools/check-docs-mdx
fern check
fern docs md check
rumdl check docs    # hence the extra lint fix commit!
```

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/dsx-exchange/blob/main/CONTRIBUTING.md).
- [x] Documentation updated, if needed.
- [ ] Tests or validation added/updated, if needed.
- [ ] License headers are present on applicable source files.
- [ ] Third-party license inventory updated, if dependencies changed.
- [ ] Security-sensitive changes were reviewed privately before public disclosure.
- [x] My commits are signed off (`git commit -s`) per the DCO.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved the formatting of external references with clickable Markdown links.
  - Updated the documentation navigation to feature the DSX Flex section and its related topics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->