### PR TITLE
fix(event-bus): proxy JetStream data APIs across domains

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -349,8 +349,9 @@ must not use built-in account names (`SYS`, `AUTH`, `AUTHX`, `CSC`, `CPC`) or
 start with `cpc` in any case.
 Extra account properties are passed through on CSC clusters except `enabled`.
 CSC owns extra-account JetStream. CPC clusters render the account as a
-CPC-to-CSC leaf proxy: plain `$JS.API.>` requests are mapped to the CSC
-JetStream domain and sent over the account leaf connection. The chart generates
+CPC-to-CSC leaf proxy. KV and Object Store use `$KV` and `$OBJ` domain API
+subjects outside `$JS.API`, so all three namespaces are mapped separately.
+The chart generates
 `secretKeyRef` env vars for `LEAF_{ACCOUNT}_USER_SEED` on CPC clusters and
 `NKEY_LEAF_{ACCOUNT}_CPC_{id}_PUBKEY` on CSC clusters. Missing secrets fail pod
 startup because the generated refs are not optional.
@@ -361,7 +362,10 @@ define manual NKey permission entries with those names.
 
 ### mTLS MQTT Endpoint
 
-The chart can deploy a separate NATS instance (`nats-mtls`) that accepts MQTT connections authenticated with client certificates (mTLS). This instance has no JetStream of its own; it connects to the main NATS cluster via leaf nodes and forwards auth requests through the shared auth-callout service.
+The chart can deploy a separate NATS instance (`nats-mtls`) that accepts MQTT
+connections authenticated with client certificates. It has no JetStream. It
+connects to the main NATS cluster through leaf nodes and forwards auth requests
+to the shared auth-callout service.
 
 ```yaml
 global:
@@ -458,8 +462,7 @@ External access via Envoy Gateway TCPRoutes/TLSRoutes:
 | `nats:4222` | 4222 | Main NATS clients |
 | `nats:7422` | 7422 | Leaf nodes |
 | `nats:1883` | 1883 | MQTT 3.1.1 |
-| `nats-mtls:4222` | 4222 | mTLS NATS clients |
-| `nats-mtls:1883` | 1883 | mTLS MQTT 3.1.1 |
+| `nats-mtls:1883` | 1883 | MQTT listener used by the mTLS gateway |
 | `surveyor:7777` | 7777 | Prometheus metrics |
 
 ## Monitoring

--- a/deploy/nats-event-bus/templates/nats-accounts-config.yaml
+++ b/deploy/nats-event-bus/templates/nats-accounts-config.yaml
@@ -57,6 +57,8 @@ data:
       ]
       mappings: {
         "$JS.API.>": "$JS.CSC.API.>"
+        "$KV.>": "$JS.CSC.API.$KV.>"
+        "$OBJ.>": "$JS.CSC.API.$OBJ.>"
         "$MQTT.sess.*.>": "$MQTT.sess.CSC.>"
       }
     }
@@ -93,6 +95,8 @@ data:
 {{ include "nats-event-bus.natsConfFields" (omit $config "enabled" "leaf" "jetstream" "mappings") | indent 6 }}
       mappings: {
         "$JS.API.>": "$JS.CSC.API.>"
+        "$KV.>": "$JS.CSC.API.$KV.>"
+        "$OBJ.>": "$JS.CSC.API.$OBJ.>"
       }
     }
     {{- end }}

--- a/deploy/nats-event-bus/templates/nats-mtls-accounts-config.yaml
+++ b/deploy/nats-event-bus/templates/nats-mtls-accounts-config.yaml
@@ -23,6 +23,9 @@ data:
       jetstream: false
       mappings: {
         "$JS.API.>": "$JS.CSC.API.>"
+        # Keep domain mappings consistent with the main NATS account.
+        "$KV.>": "$JS.CSC.API.$KV.>"
+        "$OBJ.>": "$JS.CSC.API.$OBJ.>"
         "$MQTT.sess.*.>": "$MQTT.sess.CSC.>"
       }
     }
@@ -31,6 +34,9 @@ data:
       jetstream: false
       mappings: {
         "$JS.API.>": "$JS.CPC.API.>"
+        # Keep domain mappings consistent with the main NATS account.
+        "$KV.>": "$JS.CPC.API.$KV.>"
+        "$OBJ.>": "$JS.CPC.API.$OBJ.>"
         "$MQTT.sess.*.>": "$MQTT.sess.CPC.>"
       }
     }

--- a/deploy/nats-event-bus/values.yaml
+++ b/deploy/nats-event-bus/values.yaml
@@ -78,8 +78,8 @@ global:
     #
     # Extra accounts are rendered as native accounts on every cluster where they
     # are enabled. CSC owns extra-account JetStream. CPC clusters add a
-    # CPC-to-CSC leaf connection for the account and map plain $JS.API.>
-    # requests to the CSC JetStream domain.
+    # CPC-to-CSC leaf connection for the account and map $JS.API, $KV, and $OBJ
+    # to the CSC JetStream domain.
     #
     # Every enabled extra account gets its own CPC-to-CSC leaf connection by
     # default. The chart expects leaf secrets to follow the same per-leaf pattern

--- a/local/README.md
+++ b/local/README.md
@@ -116,10 +116,6 @@ For the testing strategy (functional and performance coverage), see
 
 ## Development
 
-### Known Issues
-
-- **TODO: Fix mTLS JetStream with Synadia support** - JetStream API requests (`$JS.API.*`) are not routing through NATS-mTLS leaf nodes. Need to investigate Synadia NATS configuration for enabling JetStream API forwarding through leaf nodes without local JetStream persistence. mTLS tests are currently skipped.
-
 ### MQTT Benchmark Suite
 
 Run standardized MQTT broker benchmarks following the [Open MQTT Benchmark Suite](https://github.com/emqx/mqttbs):

--- a/local/mqtt-client/pkg/client/client.go
+++ b/local/mqtt-client/pkg/client/client.go
@@ -15,16 +15,18 @@ import (
 )
 
 type Config struct {
-	Broker      string
-	ClientID    string
-	Username    string
-	Password    string
-	QoS         byte
-	TLS         bool
-	TLSCert     string // Path to client certificate
-	TLSKey      string // Path to client key
-	TLSCA       string // Path to CA certificate
-	TLSInsecure bool   // Skip TLS verification
+	Broker            string
+	ClientID          string
+	Username          string
+	Password          string
+	QoS               byte
+	TLS               bool
+	TLSCert           string // Path to client certificate
+	TLSKey            string // Path to client key
+	TLSCA             string // Path to CA certificate
+	TLSInsecure       bool   // Skip TLS verification
+	PersistentSession bool
+	MessageHandler    mqtt.MessageHandler
 }
 
 type Client struct {
@@ -74,7 +76,8 @@ func New(config Config) (*Client, error) {
 		opts.SetTLSConfig(tlsConfig)
 	}
 
-	opts.SetCleanSession(true)
+	opts.SetCleanSession(!config.PersistentSession)
+	opts.SetDefaultPublishHandler(config.MessageHandler)
 	opts.SetAutoReconnect(false) // Disable auto-reconnect for tests
 	opts.SetConnectRetry(false)  // Disable connect retry for fast failure
 	opts.SetConnectTimeout(5 * time.Second)

--- a/local/mqtt-client/tests/functional/mtls_test.go
+++ b/local/mqtt-client/tests/functional/mtls_test.go
@@ -5,8 +5,10 @@ package functional
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,6 +16,7 @@ import (
 	"github.com/NVIDIA/dsx-exchange/local/mqtt-client/pkg/client"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/google/uuid"
+	"github.com/nats-io/nats.go"
 )
 
 // getMTLSBrokerURL returns the mTLS broker URL from environment or default
@@ -42,6 +45,188 @@ func getMTLSCertPaths() (cert, key, ca string) {
 	return fmt.Sprintf("%s/client.pem", certDir),
 		fmt.Sprintf("%s/client-key.pem", certDir),
 		fmt.Sprintf("%s/ca.pem", certDir)
+}
+
+type mtlsEndpoint struct {
+	name    string
+	broker  string
+	certDir string
+}
+
+func getMTLSEndpoints() []mtlsEndpoint {
+	if broker := os.Getenv("MQTT_MTLS_BROKER"); broker != "" {
+		cert, _, _ := getMTLSCertPaths()
+		return []mtlsEndpoint{{name: "configured", broker: broker, certDir: strings.TrimSuffix(cert, "/client.pem")}}
+	}
+	return []mtlsEndpoint{
+		{name: "CSC", broker: "ssl://172.18.200.1:8883", certDir: "../../../nats/certs/csc"},
+		{name: "CPC-1", broker: "ssl://172.18.201.1:8883", certDir: "../../../nats/certs/cpc-1"},
+		{name: "CPC-2", broker: "ssl://172.18.202.1:8883", certDir: "../../../nats/certs/cpc-2"},
+	}
+}
+
+func (endpoint mtlsEndpoint) config(clientID string) client.Config {
+	return client.Config{
+		Broker:   endpoint.broker,
+		ClientID: clientID,
+		TLS:      true,
+		TLSCert:  endpoint.certDir + "/client.pem",
+		TLSKey:   endpoint.certDir + "/client-key.pem",
+		TLSCA:    endpoint.certDir + "/ca.pem",
+	}
+}
+
+func (endpoint mtlsEndpoint) natsBroker() string {
+	return strings.Replace(strings.Replace(endpoint.broker, "ssl://", "nats://", 1), ":8883", ":4222", 1)
+}
+
+func connectMTLSClient(t *testing.T, config client.Config) *client.Client {
+	t.Helper()
+
+	mqttClient, err := client.New(config)
+	if err != nil {
+		t.Fatalf("create mTLS client: %v", err)
+	}
+	if err := mqttClient.Connect(); err != nil {
+		t.Fatalf("connect mTLS client: %v", err)
+	}
+	return mqttClient
+}
+
+func TestRestrictedMTLSMQTTQoS1(t *testing.T) {
+	for _, endpoint := range getMTLSEndpoints() {
+		t.Run(endpoint.name, func(t *testing.T) {
+			topic := "test/mtls/qos1/" + uuid.NewString()
+			received := make(chan mqtt.Message, 1)
+
+			// Verify permitted QoS 1 traffic.
+			subscriber := connectMTLSClient(t, endpoint.config("qos1-sub-"+uuid.NewString()))
+			defer subscriber.Disconnect()
+			if err := subscriber.Subscribe(topic, 1, func(_ mqtt.Client, message mqtt.Message) {
+				received <- message
+			}); err != nil {
+				t.Fatalf("subscribe at QoS 1: %v", err)
+			}
+
+			publisher := connectMTLSClient(t, endpoint.config("qos1-pub-"+uuid.NewString()))
+			defer publisher.Disconnect()
+			payload := []byte("qos1")
+			if err := publisher.Publish(topic, payload, 1, false); err != nil {
+				t.Fatalf("publish at QoS 1: %v", err)
+			}
+
+			message := waitForMQTTMessage(t, received)
+			if message.Qos() != 1 || string(message.Payload()) != string(payload) {
+				t.Fatalf("received QoS %d payload %q", message.Qos(), message.Payload())
+			}
+
+			// Reject subjects outside test.>.
+			forbiddenSubject := "forbidden." + uuid.NewString()
+			observer, err := nats.Connect(endpoint.natsBroker())
+			if err != nil {
+				t.Fatalf("connect permission observer: %v", err)
+			}
+			defer observer.Close()
+			observed, err := observer.SubscribeSync(forbiddenSubject)
+			if err != nil {
+				t.Fatalf("subscribe permission observer: %v", err)
+			}
+			if err := observer.Flush(); err != nil {
+				t.Fatalf("flush permission observer: %v", err)
+			}
+
+			// MQTT 3.1.1 acknowledges QoS 1 publishes even when NATS denies the subject.
+			if err := publisher.Publish(strings.ReplaceAll(forbiddenSubject, ".", "/"), nil, 1, false); err != nil {
+				t.Fatalf("complete denied QoS 1 publish: %v", err)
+			}
+			if _, err := observed.NextMsg(500 * time.Millisecond); !errors.Is(err, nats.ErrTimeout) {
+				t.Fatalf("wait for denied publish: %v", err)
+			}
+			if err := subscriber.Subscribe("forbidden/#", 1, nil); err == nil {
+				t.Fatal("subscription outside the application permission succeeded")
+			}
+		})
+	}
+}
+
+func TestRestrictedMTLSMQTTPersistentSession(t *testing.T) {
+	for _, endpoint := range getMTLSEndpoints() {
+		t.Run(endpoint.name, func(t *testing.T) {
+			clientID := "persistent-" + uuid.NewString()
+			topic := "test/mtls/persistent/" + uuid.NewString()
+			config := endpoint.config(clientID)
+			config.PersistentSession = true
+
+			// Keep the subscription after disconnect.
+			subscriber := connectMTLSClient(t, config)
+			if err := subscriber.Subscribe(topic, 1, nil); err != nil {
+				t.Fatalf("create persistent subscription: %v", err)
+			}
+			subscriber.Disconnect()
+
+			// Queue a message while the subscriber is offline.
+			publisher := connectMTLSClient(t, endpoint.config("persistent-pub-"+uuid.NewString()))
+			if err := publisher.Publish(topic, []byte("stored while offline"), 1, false); err != nil {
+				publisher.Disconnect()
+				t.Fatalf("publish while subscriber is offline: %v", err)
+			}
+			publisher.Disconnect()
+
+			// Resume the session with the same client ID.
+			received := make(chan mqtt.Message, 1)
+			config.MessageHandler = func(_ mqtt.Client, message mqtt.Message) {
+				received <- message
+			}
+			reconnected := connectMTLSClient(t, config)
+			defer reconnected.Disconnect()
+			if message := waitForMQTTMessage(t, received); string(message.Payload()) != "stored while offline" {
+				t.Fatalf("persistent payload %q", message.Payload())
+			}
+		})
+	}
+}
+
+func TestRestrictedMTLSMQTTRetainedMessage(t *testing.T) {
+	for _, endpoint := range getMTLSEndpoints() {
+		t.Run(endpoint.name, func(t *testing.T) {
+			topic := "test/mtls/retained/" + uuid.NewString()
+
+			// Store the retained message.
+			publisher := connectMTLSClient(t, endpoint.config("retained-pub-"+uuid.NewString()))
+			defer publisher.Disconnect()
+			defer publisher.Publish(topic, nil, 1, true)
+			if err := publisher.Publish(topic, []byte("retained"), 1, true); err != nil {
+				t.Fatalf("publish retained message: %v", err)
+			}
+
+			// Deliver it to a new subscriber.
+			received := make(chan mqtt.Message, 1)
+			subscriber := connectMTLSClient(t, endpoint.config("retained-sub-"+uuid.NewString()))
+			defer subscriber.Disconnect()
+			if err := subscriber.Subscribe(topic, 1, func(_ mqtt.Client, message mqtt.Message) {
+				received <- message
+			}); err != nil {
+				t.Fatalf("subscribe to retained message: %v", err)
+			}
+
+			message := waitForMQTTMessage(t, received)
+			if !message.Retained() || string(message.Payload()) != "retained" {
+				t.Fatalf("received retained=%t payload=%q", message.Retained(), message.Payload())
+			}
+		})
+	}
+}
+
+func waitForMQTTMessage(t *testing.T, messages <-chan mqtt.Message) mqtt.Message {
+	t.Helper()
+
+	select {
+	case message := <-messages:
+		return message
+	case <-time.After(15 * time.Second):
+		t.Fatal("timeout waiting for MQTT message")
+		return nil
+	}
 }
 
 func TestMTLSConnection(t *testing.T) {

--- a/local/mqtt-client/tests/functional/nats_leaf_test.go
+++ b/local/mqtt-client/tests/functional/nats_leaf_test.go
@@ -108,18 +108,114 @@ func TestLaunchLayerJetStreamStoresLeafMessages(t *testing.T) {
 }
 
 func TestLaunchLayerJetStreamAPIProxiesToCSC(t *testing.T) {
-	clusters := getNATSClusters()
-	csc := findNATSCluster(clusters, "CSC")
-	if csc == nil {
-		t.Fatal("CSC NATS cluster not found")
+	endpoints := launchLayerTestEndpoints(t)
+	for i, creator := range endpoints {
+		t.Run(creator.cluster.name, func(t *testing.T) {
+			testLaunchLayerJetStreamAPI(
+				t,
+				creator,
+				endpoints[(i+1)%len(endpoints)],
+				endpoints[(i+2)%len(endpoints)],
+				endpoints,
+			)
+		})
+	}
+}
+
+func TestLaunchLayerJetStreamKVProxiesToCSC(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	defer cancel()
+
+	endpoints := launchLayerTestEndpoints(t)
+	cpc1Conn, cpc1JS := connectLaunchLayerJetStream(t, ctx, endpoints[1])
+	defer cpc1Conn.Close()
+	cpc2Conn, cpc2JS := connectLaunchLayerJetStream(t, ctx, endpoints[2])
+	defer cpc2Conn.Close()
+	cscConn, cscJS := connectLaunchLayerJetStream(t, ctx, endpoints[0])
+	defer cscConn.Close()
+
+	// Create through CPC-1.
+	bucketName := testResourceName("LL_KV")
+	if _, err := cpc1JS.CreateKeyValue(&nats.KeyValueConfig{
+		Bucket: bucketName, Storage: nats.MemoryStorage, Replicas: 1,
+	}); err != nil {
+		t.Fatalf("create KV bucket through CPC-1: %v", err)
+	}
+	defer cpc1JS.DeleteKeyValue(bucketName)
+
+	cpc2KV, err := cpc2JS.KeyValue(bucketName)
+	if err != nil {
+		t.Fatalf("bind KV bucket through CPC-2: %v", err)
+	}
+	cscKV, err := cscJS.KeyValue(bucketName)
+	if err != nil {
+		t.Fatalf("bind KV bucket through CSC: %v", err)
 	}
 
-	streamOwner := launchLayerCSC(t, *csc)
-	for _, cluster := range clusters {
-		cluster := cluster
-		t.Run(cluster.name, func(t *testing.T) {
-			testLaunchLayerJetStreamAPI(t, launchLayerCluster(t, cluster), streamOwner)
-		})
+	// Write through CPC-2 and read through CSC.
+	key := "cross-cluster"
+	first := []byte("from-cpc-2")
+	revision, err := cpc2KV.Put(key, first)
+	if err != nil {
+		t.Fatalf("put KV value through CPC-2: %v", err)
+	}
+	requireKVValue(t, cscKV, key, first)
+
+	// Update through CSC and read through CPC-2.
+	second := []byte("from-csc")
+	if _, err := cscKV.Update(key, second, revision); err != nil {
+		t.Fatalf("update KV value through CSC: %v", err)
+	}
+	requireKVValue(t, cpc2KV, key, second)
+	if err := cpc2KV.Delete(key); err != nil {
+		t.Fatalf("delete KV value through CPC-2: %v", err)
+	}
+}
+
+func TestLaunchLayerJetStreamObjectStoreProxiesToCSC(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	defer cancel()
+
+	endpoints := launchLayerTestEndpoints(t)
+	cpc1Conn, cpc1JS := connectLaunchLayerJetStream(t, ctx, endpoints[1])
+	defer cpc1Conn.Close()
+	cpc2Conn, cpc2JS := connectLaunchLayerJetStream(t, ctx, endpoints[2])
+	defer cpc2Conn.Close()
+	cscConn, cscJS := connectLaunchLayerJetStream(t, ctx, endpoints[0])
+	defer cscConn.Close()
+
+	// Create through CPC-1.
+	bucketName := testResourceName("LL_OBJ")
+	if _, err := cpc1JS.CreateObjectStore(&nats.ObjectStoreConfig{
+		Bucket: bucketName, Storage: nats.MemoryStorage, Replicas: 1,
+	}); err != nil {
+		t.Fatalf("create Object Store through CPC-1: %v", err)
+	}
+	defer cpc1JS.DeleteObjectStore(bucketName)
+
+	cpc2Store, err := cpc2JS.ObjectStore(bucketName)
+	if err != nil {
+		t.Fatalf("bind Object Store through CPC-2: %v", err)
+	}
+	cscStore, err := cscJS.ObjectStore(bucketName)
+	if err != nil {
+		t.Fatalf("bind Object Store through CSC: %v", err)
+	}
+
+	// Write through CPC-2 and read through CSC.
+	objectName, payload := "cross-cluster", []byte("object-from-cpc-2")
+	if _, err := cpc2Store.PutBytes(objectName, payload); err != nil {
+		t.Fatalf("put object through CPC-2: %v", err)
+	}
+	got, err := cscStore.GetBytes(objectName)
+	if err != nil {
+		t.Fatalf("get object through CSC: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("object payload %q, want %q", got, payload)
+	}
+	if err := cpc2Store.Delete(objectName); err != nil {
+		t.Fatalf("delete object through CPC-2: %v", err)
 	}
 }
 
@@ -193,62 +289,144 @@ func testLaunchLayerJetStream(t *testing.T, source launchLayerEndpoint, streamOw
 	}
 }
 
-func testLaunchLayerJetStreamAPI(t *testing.T, endpoint launchLayerEndpoint, streamOwner launchLayerEndpoint) {
+func testLaunchLayerJetStreamAPI(
+	t *testing.T,
+	creator launchLayerEndpoint,
+	updater launchLayerEndpoint,
+	deleter launchLayerEndpoint,
+	endpoints []launchLayerEndpoint,
+) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
 	defer cancel()
 
-	ownerConn := connectLaunchLayer(t, streamOwner)
-	defer ownerConn.Close()
+	creatorConn, creatorJS := connectLaunchLayerJetStream(t, ctx, creator)
+	defer creatorConn.Close()
 
-	ownerJS, err := ownerConn.JetStream(nats.Context(ctx))
-	if err != nil {
-		t.Fatalf("failed to create JetStream context for %s: %v", streamOwner.cluster.name, err)
-	}
-
-	conn := connectLaunchLayer(t, endpoint)
-	defer conn.Close()
-
-	js, err := conn.JetStream(nats.Context(ctx))
-	if err != nil {
-		t.Fatalf("failed to create JetStream context for %s: %v", endpoint.cluster.name, err)
-	}
-
+	// Create through CSC, CPC-1, and CPC-2.
 	token := strings.ReplaceAll(uuid.NewString(), "-", "")
 	streamName := "LL_API_" + token[:12]
-	subject := "launchlayer.jsapi." + token
-	payload := []byte(fmt.Sprintf("jetstream-api-%s-%s", endpoint.cluster.name, token))
-
-	if _, err := ownerJS.AddStream(&nats.StreamConfig{
+	subjectPrefix := "launchlayer.jsapi." + token
+	streamConfig := &nats.StreamConfig{
 		Name:     streamName,
-		Subjects: []string{subject},
+		Subjects: []string{subjectPrefix + ".>"},
 		Storage:  nats.MemoryStorage,
 		Replicas: 1,
-	}, nats.Context(ctx)); err != nil {
-		t.Fatalf("failed to create LaunchLayer stream %s on %s: %v", streamName, streamOwner.cluster.name, err)
 	}
-	defer func() {
-		if err := ownerJS.DeleteStream(streamName); err != nil && !errors.Is(err, nats.ErrStreamNotFound) {
-			t.Logf("failed to delete LaunchLayer stream %s: %v", streamName, err)
+	if _, err := creatorJS.AddStream(streamConfig, nats.Context(ctx)); err != nil {
+		t.Fatalf("create stream through %s: %v", creator.cluster.name, err)
+	}
+
+	// Update through the next cluster.
+	updaterConn, updaterJS := connectLaunchLayerJetStream(t, ctx, updater)
+	defer updaterConn.Close()
+	streamConfig.Description = "updated through " + updater.cluster.name
+	if _, err := updaterJS.UpdateStream(streamConfig, nats.Context(ctx)); err != nil {
+		t.Fatalf("update stream through %s: %v", updater.cluster.name, err)
+	}
+
+	// Inspect through every cluster.
+	for _, endpoint := range endpoints {
+		conn, js := connectLaunchLayerJetStream(t, ctx, endpoint)
+		info, err := js.StreamInfo(streamName, nats.Context(ctx))
+		conn.Close()
+		if err != nil {
+			t.Fatalf("inspect stream through %s: %v", endpoint.cluster.name, err)
 		}
-	}()
+		if info.Config.Description != streamConfig.Description {
+			t.Fatalf("stream description through %s is %q", endpoint.cluster.name, info.Config.Description)
+		}
+	}
 
-	ack, err := js.Publish(subject, payload, nats.Context(ctx))
+	// Publish, fetch, and ACK through every cluster.
+	for _, endpoint := range endpoints {
+		conn, js := connectLaunchLayerJetStream(t, ctx, endpoint)
+		subject := subjectPrefix + "." + strings.ToLower(endpoint.cluster.name)
+		consumer, err := js.PullSubscribe(
+			subject,
+			"C_"+strings.ReplaceAll(endpoint.cluster.name, "-", "_"),
+			nats.BindStream(streamName),
+		)
+		if err != nil {
+			conn.Close()
+			t.Fatalf("create pull consumer through %s: %v", endpoint.cluster.name, err)
+		}
+		if _, err := js.Publish(subject, []byte("from-"+endpoint.cluster.name), nats.Context(ctx)); err != nil {
+			conn.Close()
+			t.Fatalf("publish through %s: %v", endpoint.cluster.name, err)
+		}
+		messages, err := consumer.Fetch(1, nats.Context(ctx))
+		if err != nil {
+			conn.Close()
+			t.Fatalf("fetch through %s: %v", endpoint.cluster.name, err)
+		}
+		if !strings.HasPrefix(messages[0].Reply, "$JS.ACK."+streamName+".") {
+			conn.Close()
+			t.Fatalf("ACK subject %q does not identify stream %s", messages[0].Reply, streamName)
+		}
+		// NATS 2.12 ACK subjects do not include a domain.
+		if err := messages[0].AckSync(nats.Context(ctx)); err != nil {
+			conn.Close()
+			t.Fatalf("ACK through %s: %v", endpoint.cluster.name, err)
+		}
+		conn.Close()
+	}
+
+	// Delete through the remaining cluster.
+	deleterConn, deleterJS := connectLaunchLayerJetStream(t, ctx, deleter)
+	defer deleterConn.Close()
+	if err := deleterJS.DeleteStream(streamName, nats.Context(ctx)); err != nil {
+		t.Fatalf("delete stream through %s: %v", deleter.cluster.name, err)
+	}
+}
+
+func connectLaunchLayerJetStream(
+	t *testing.T,
+	ctx context.Context,
+	endpoint launchLayerEndpoint,
+) (*nats.Conn, nats.JetStreamContext) {
+	t.Helper()
+
+	conn := connectLaunchLayer(t, endpoint)
+	js, err := conn.JetStream(nats.Context(ctx))
 	if err != nil {
-		t.Fatalf("failed to publish LaunchLayer JetStream payload through %s: %v", endpoint.cluster.name, err)
+		conn.Close()
+		t.Fatalf("create JetStream context for %s: %v", endpoint.cluster.name, err)
 	}
-	if ack.Stream != streamName {
-		t.Fatalf("JetStream publish ack stream %q, want %q", ack.Stream, streamName)
-	}
+	return conn, js
+}
 
-	got := waitForStoredLaunchLayerMessage(t, ctx, ownerJS, streamName, subject)
-	if string(got.Data) != string(payload) {
-		t.Fatalf("stored payload %q, want %q", got.Data, payload)
-	}
+func launchLayerTestEndpoints(t *testing.T) []launchLayerEndpoint {
+	t.Helper()
 
-	t.Logf("JetStream API from LaunchLayer on %s stored in %s at sequence %d",
-		endpoint.cluster.name, streamOwner.cluster.name, got.Sequence)
+	clusters := getNATSClusters()
+	csc := findNATSCluster(clusters, "CSC")
+	if csc == nil {
+		t.Fatal("CSC NATS cluster not found")
+	}
+	return []launchLayerEndpoint{
+		launchLayerCSC(t, *csc),
+		launchLayerCPC(t, clusters, "1"),
+		launchLayerCPC(t, clusters, "2"),
+	}
+}
+
+func testResourceName(prefix string) string {
+	token := strings.ReplaceAll(uuid.NewString(), "-", "")
+	return prefix + "_" + token[:12]
+}
+
+func requireKVValue(t *testing.T, bucket nats.KeyValue, key string, want []byte) {
+	t.Helper()
+
+	entry, err := bucket.Get(key)
+	if err != nil {
+		t.Fatalf("get KV key %q: %v", key, err)
+	}
+	if string(entry.Value()) != string(want) {
+		t.Fatalf("KV value %q, want %q", entry.Value(), want)
+	}
 }
 
 func waitForStoredLaunchLayerMessage(

--- a/local/nats/k8s/cpc/cpc-1.yaml
+++ b/local/nats/k8s/cpc/cpc-1.yaml
@@ -13,3 +13,9 @@ global:
           mqtt-client:
             identity: "CN=mqtt-client.cpc-1"
             account: "CPC"
+            # MQTT persistence uses the server's internal account client.
+            permissions:
+              pub:
+                allow: ["test.>"]
+              sub:
+                allow: ["test.>"]

--- a/local/nats/k8s/cpc/cpc-2.yaml
+++ b/local/nats/k8s/cpc/cpc-2.yaml
@@ -13,3 +13,9 @@ global:
           mqtt-client:
             identity: "CN=mqtt-client.cpc-2"
             account: "CPC"
+            # MQTT persistence uses the server's internal account client.
+            permissions:
+              pub:
+                allow: ["test.>"]
+              sub:
+                allow: ["test.>"]

--- a/local/nats/k8s/cpc/values.yaml
+++ b/local/nats/k8s/cpc/values.yaml
@@ -59,7 +59,8 @@ global:
             account: "LaunchLayer"
             permissions:
               pub:
-                allow: ["launchlayer.>", "$JS.API.>"]
+                # NATS authorizes mapped subjects. Raw JS/KV/OBJ are denied.
+                allow: ["launchlayer.>", "$JS.CSC.API.>", "$O.>", "$JS.ACK.>"]
               sub:
                 allow: ["launchlayer.>", "_INBOX.>"]
         noauth:

--- a/local/nats/k8s/csc/values.yaml
+++ b/local/nats/k8s/csc/values.yaml
@@ -50,12 +50,18 @@ global:
             account: "LaunchLayer"
             permissions:
               pub:
-                allow: ["launchlayer.>", "$JS.API.>"]
+                allow: ["launchlayer.>", "$JS.API.>", "$KV.>", "$OBJ.>", "$O.>", "$JS.ACK.>"]
               sub:
                 allow: ["launchlayer.>", "_INBOX.>"]
         mtls:
           mqtt-client:
             identity: "CN=mqtt-client.csc"
             account: "CSC"
+            # MQTT persistence uses the server's internal account client.
+            permissions:
+              pub:
+                allow: ["test.>"]
+              sub:
+                allow: ["test.>"]
         noauth:
           account: "CSC"


### PR DESCRIPTION
## Summary
- proxy `$KV` and `$OBJ` through JetStream-disabled accounts
- restrict LaunchLayer and mTLS test clients
- test cross-cluster JetStream, KV, Object Store, and mTLS MQTT persistence

## Validation
- `make check`
- `go test -count=1 -v ./tests/functional -timeout 4m`
- `go test ./pkg/... ./internal/... ./cmd/...`

NO-REF




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable MQTT persistent-session behavior and a default publish handler.
  - Extended JetStream proxy routing so KeyValue and Object Store subjects map correctly across CPC/CSC endpoints.
- **Documentation**
  - Clarified JetStream subject mappings and how mTLS MQTT endpoints behave and what the verification covers.
- **Tests**
  - Refined restricted-permissions mTLS MQTT functional tests.
  - Added JetStream KV and Object Store proxy test coverage across endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->