### PR TITLE
fix(agentgateway): update to v1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DSX Exchange
 
-DSX Exchange is a monorepo for the DSX Event Bus and DSX Agent Gateway,
-including schemas, services, Helm charts, and local evaluation tooling.
+DSX Exchange is a monorepo for the DSX Event Bus and Agentgateway, including
+schemas, services, Helm charts, and local evaluation tooling.
 
 Documentation for DSX Exchange is available at [https://docs.nvidia.com/dsx-exchange](https://docs.nvidia.com/dsx-exchange).
 
@@ -12,13 +12,14 @@ DSX Exchange includes:
 - `schemas`: AsyncAPI contracts for DSX Exchange MQTT topics and payloads.
 - `auth-callout`: NATS auth callout service for OAuth2, mTLS, NKey, and no-auth profiles.
 - `dsx-agentgateway-bridge`: MCP discovery and request routing over NATS.
-- `deploy`: Helm charts for the NATS event bus and DSX Agent Gateway.
+- `deploy`: Helm charts for the NATS event bus and Agentgateway.
 - `local`: Kind-based local evaluation environment, Skaffold deployment, MQTT and MCP tests, and benchmark tooling.
 
 The event bus itself is schema agnostic. Schemas document externally visible contracts; NATS and the auth callout enforce routing, federation, and authorization behavior.
 
-The DSX Agent Gateway routes authenticated MCP requests to local and remote MCP
-servers; its bridge uses the Event Bus for remote discovery and request routing.
+Upstream Agentgateway routes authenticated MCP requests to local MCP servers.
+The `dsx-agentgateway-bridge` adds remote discovery and request routing over the
+DSX Event Bus.
 
 ## Requirements
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -31,7 +31,7 @@ auth-callout v0.1.1
   License: Apache-2.0
   Copyright: NVIDIA CORPORATION & AFFILIATES
 
-agentgateway v1.3.1
+agentgateway v1.4.1
   Source: https://github.com/agentgateway/agentgateway
   Repository: oci://cr.agentgateway.dev/charts
   License: Apache-2.0

--- a/deploy/dsx-agent-gateway/Chart.lock
+++ b/deploy/dsx-agent-gateway/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: agentgateway
   repository: oci://cr.agentgateway.dev/charts
-  version: v1.3.1
+  version: v1.4.1
 - name: valkey
   repository: https://valkey-io.github.io/valkey-helm
   version: 0.9.4
-digest: sha256:483612ae7b889a43e4b741a9748739ab46c61c37695ccb3f234cac8b3b86f40b
-generated: "2026-07-10T20:55:36.049095192Z"
+digest: sha256:95a90516b959004c91319be19730bd8470b5018be704627fae2e86d568b937f3
+generated: "2026-07-30T14:31:44.80307-07:00"

--- a/deploy/dsx-agent-gateway/Chart.yaml
+++ b/deploy/dsx-agent-gateway/Chart.yaml
@@ -6,7 +6,7 @@ name: dsx-agent-gateway
 description: Agentgateway deployment chart with optional dsx-agentgateway-bridge routing, rate limiting, observability, and defaults.
 type: application
 version: 0.3.1
-appVersion: "0.3.0"
+appVersion: "0.3.1"
 home: https://github.com/NVIDIA/dsx-exchange
 sources:
   - https://github.com/NVIDIA/dsx-exchange

--- a/deploy/dsx-agent-gateway/Chart.yaml
+++ b/deploy/dsx-agent-gateway/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: dsx-agent-gateway
-description: DSX Agent Gateway chart for agentgateway-based MCP ingress, bridge routing, rate limiting, and optional bundled agentgateway controller and Valkey.
+description: Agentgateway deployment chart with optional dsx-agentgateway-bridge routing, rate limiting, observability, and defaults.
 type: application
 version: 0.3.0
 appVersion: "0.3.0"
@@ -13,7 +13,7 @@ sources:
 
 dependencies:
   - name: agentgateway
-    version: "v1.3.1"
+    version: "v1.4.1"
     repository: oci://cr.agentgateway.dev/charts
     condition: agentgateway.enabled
   - name: valkey

--- a/deploy/dsx-agent-gateway/Chart.yaml
+++ b/deploy/dsx-agent-gateway/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: dsx-agent-gateway
 description: Agentgateway deployment chart with optional dsx-agentgateway-bridge routing, rate limiting, observability, and defaults.
 type: application
-version: 0.3.1
-appVersion: "0.3.1"
+version: 0.3.0
+appVersion: "0.3.0"
 home: https://github.com/NVIDIA/dsx-exchange
 sources:
   - https://github.com/NVIDIA/dsx-exchange

--- a/deploy/dsx-agent-gateway/Chart.yaml
+++ b/deploy/dsx-agent-gateway/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: dsx-agent-gateway
 description: Agentgateway deployment chart with optional dsx-agentgateway-bridge routing, rate limiting, observability, and defaults.
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "0.3.0"
 home: https://github.com/NVIDIA/dsx-exchange
 sources:

--- a/deploy/dsx-agent-gateway/README.md
+++ b/deploy/dsx-agent-gateway/README.md
@@ -1,17 +1,17 @@
-# DSX Agent Gateway Helm Chart
+# Agentgateway Deployment Helm Chart
 
 ## What the chart installs
 
-The chart deploys one DSX Agent Gateway that routes `/mcp` requests to selected
-in-cluster MCP Services, authenticates callers, and applies tenant authorization
-and rate limits. By default it also installs the pinned agentgateway controller,
-a two-replica rate-limit service, and Valkey via chart 0.9.4 for
-rate-limit counters. The optional bridge connects gateway shards through NATS.
+The chart deploys Agentgateway for MCP ingress. It also packages
+optional `dsx-agentgateway-bridge` cross-shard routing through NATS, deployment
+defaults, rate limiting, and observability resources. By default it installs the
+pinned Agentgateway controller, a two-replica rate-limit service, and Valkey via
+chart 0.9.4 for rate-limit counters.
 
 ## Prerequisites
 
 - Helm and `kubectl`.
-- Gateway API v1.5.1 CRDs and agentgateway v1.3.1 CRDs installed by a cluster
+- Gateway API v1.5.1 CRDs and agentgateway v1.4.1 CRDs installed by a cluster
   administrator. This chart does not install those CRDs.
 - The DSX observability stack, including Prometheus Operator CRDs and the
   OpenTelemetry Operator resources shown under Operations. Disable the
@@ -22,7 +22,7 @@ rate-limit counters. The optional bridge connects gateway shards through NATS.
 
 ## Supported deployment model
 
-The DSX Agent Gateway listens on plaintext HTTP port 80 through an internal
+The Agentgateway dataplane listens on plaintext HTTP port 80 through an internal
 `ClusterIP` Service. `NodePort` is the only other supported Service type. An
 operator-owned edge can route to this Service. See the
 [HTTP-only Envoy Gateway edge example](examples/envoy-edge-route.yaml).
@@ -135,7 +135,7 @@ helm upgrade --install agentgateway-crds \
   oci://cr.agentgateway.dev/charts/agentgateway-crds \
   --namespace agentgateway-system \
   --create-namespace \
-  --version v1.3.1
+  --version v1.4.1
 ```
 
 Download the chart dependencies:
@@ -168,7 +168,7 @@ helm upgrade dsx-agent-gateway deploy/dsx-agent-gateway \
 
 ## Gateway programming status
 
-Wait until the DSX Agent Gateway is programmed:
+Wait until the Agentgateway resource is programmed:
 
 ```bash
 kubectl wait \
@@ -253,7 +253,7 @@ valkey:
 
 | Component | Metrics source | Tracing source | Configuration source |
 |---|---|---|---|
-| DSX Agent Gateway dataplane | Native agentgateway Prometheus endpoint | Native agentgateway tracing | `observability` values and `AgentgatewayPolicy` |
+| Agentgateway dataplane | Native agentgateway Prometheus endpoint | Native agentgateway tracing | `observability` values and `AgentgatewayPolicy` |
 | agentgateway controller | Native controller Prometheus endpoint | Not supported upstream | Upstream agentgateway values and chart-owned discovery |
 | Rate-limit service | Native Prometheus support | Native OpenTelemetry support | `observability` values mapped to native settings |
 | Bridge | OpenTelemetry Go runtime and HTTP instrumentation | OpenTelemetry Go HTTP instrumentation and SDK | Standard OpenTelemetry environment configuration |

--- a/deploy/dsx-agent-gateway/values.yaml
+++ b/deploy/dsx-agent-gateway/values.yaml
@@ -19,10 +19,10 @@ agentgateway:
         health: 9093
         metrics: 9092
     image:
-      tag: v1.3.1@sha256:10ba2e2232df4d131ad41855b1a7cdb33556a63d89f42adf299979b124fe6170
+      tag: v1.4.1@sha256:8b9e2bbe65b6a4b2ed93acd4fd0ede11f1eb2cfa8495e2b67c2d890e7fce8cec
   proxy:
     image:
-      tag: v1.3.1@sha256:c3ce7b75da90fef70239befcc1c3adc05152d7b9dd21fcb8351178026a2c4381
+      tag: v1.4.1@sha256:efd79355b89094a8225a9db465d9a01dc656b377f0bab458761b935a13231d29
 
 gateway:
   replicaCount: 3

--- a/dsx-agentgateway-bridge/README.md
+++ b/dsx-agentgateway-bridge/README.md
@@ -1,6 +1,6 @@
-# DSX Agent Gateway Bridge
+# dsx-agentgateway-bridge
 
-One entry DSX Agent Gateway exposes remote shard catalogs through the bridge.
+One entry Agentgateway exposes remote shard catalogs through the bridge.
 Bridge processes keep no MCP session state.
 
 The hub is a target behind the entry gateway. Leaves sit in front of shard
@@ -14,14 +14,14 @@ Broader dataplane validation is documented at the repo root.
 ```mermaid
 flowchart TB
     caller["MCP caller"]
-    entry["Entry DSX Agent Gateway"]
+    entry["Entry Agentgateway"]
     hub["Bridge hub"]
     nats["DSX Exchange NATS"]
 
     subgraph shardN["Shard N"]
         direction TB
         leafN["Bridge leaf"]
-        gatewayN["DSX Agent Gateway"]
+        gatewayN["Agentgateway"]
         domainsN["Domain MCP servers"]
         leafN -->|stateless /mcp| gatewayN
         gatewayN -->|MCP passthrough| domainsN
@@ -30,7 +30,7 @@ flowchart TB
     subgraph shard2["Shard 2"]
         direction TB
         leaf2["Bridge leaf"]
-        gateway2["DSX Agent Gateway"]
+        gateway2["Agentgateway"]
         domains2["Domain MCP servers"]
         leaf2 -->|stateless /mcp| gateway2
         gateway2 -->|MCP passthrough| domains2
@@ -39,7 +39,7 @@ flowchart TB
     subgraph shard1["Shard 1"]
         direction TB
         leaf1["Bridge leaf"]
-        gateway1["DSX Agent Gateway"]
+        gateway1["Agentgateway"]
         domains1["Domain MCP servers"]
         leaf1 -->|stateless /mcp| gateway1
         gateway1 -->|MCP passthrough| domains1
@@ -66,7 +66,7 @@ The hub also performs a synchronous refresh during startup.
 ```mermaid
 sequenceDiagram
     participant Caller
-    participant Entry as Entry DSX Agent Gateway
+    participant Entry as Entry Agentgateway
     box Hub process
     participant Hub as Bridge hub
     participant Cache as Shard cache
@@ -118,11 +118,11 @@ Example for a list response from shard `cpc-1`:
 ```mermaid
 sequenceDiagram
     participant Caller
-    participant Entry as Entry DSX Agent Gateway
+    participant Entry as Entry Agentgateway
     participant Hub as Bridge hub
     participant Bus as DSX Exchange NATS
     participant Leaf as One bridge leaf
-    participant Remote as Remote DSX Agent Gateway
+    participant Remote as Remote Agentgateway
 
     Caller->>Entry: catalog list method
     Entry->>Hub: bridge target list
@@ -153,11 +153,11 @@ resource-reference completion are not supported by the stateless bridge.
 ```mermaid
 sequenceDiagram
     participant Caller
-    participant Entry as Entry DSX Agent Gateway
+    participant Entry as Entry Agentgateway
     participant Hub as Bridge hub
     participant Bus as DSX Exchange NATS
     participant Leaf as Selected-shard leaf
-    participant Remote as Shard DSX Agent Gateway
+    participant Remote as Shard Agentgateway
 
     Caller->>Entry: request with shard value
     Entry->>Hub: bridge target request
@@ -182,7 +182,7 @@ sequenceDiagram
     participant Caller
     participant Hub as Bridge hub
     participant Leaf as Owning leaf instance
-    participant Gateway as Shard DSX Agent Gateway
+    participant Gateway as Shard Agentgateway
 
     Caller->>Hub: MCP request
     Hub->>Leaf: request through shard queue
@@ -219,7 +219,7 @@ JSON-RPC notifications, including `notifications/initialized`, list-change
 notifications, and task-status notifications, return HTTP 202 with no body.
 Methods that need MCP session state, client state, or resource path routing in
 the bridge return an unsupported JSON-RPC error. Routed shard invocations
-preserve the leaf DSX Agent Gateway's streamable HTTP response. JSON responses
+preserve the leaf Agentgateway's streamable HTTP response. JSON responses
 return as one ordinary JSON-RPC response. An SSE response identifies its leaf
 instance in the initial reply. The hub then uses ordinary request-reply reads
 against that instance. Each read returns data, a pending marker, or EOF. Reads

--- a/local/agent-gateway/charts/test-backends/test-mcp-backend/main.go
+++ b/local/agent-gateway/charts/test-backends/test-mcp-backend/main.go
@@ -67,8 +67,8 @@ func newHandler() http.Handler {
 		sessions: make(map[string]*legacyErrorSSESession),
 	}
 	mux.HandleFunc("/healthz", handleHealthz)
-	mux.Handle("/legacy-sse", legacySSE)
-	mux.Handle("/legacy-message", legacySSE)
+	mux.HandleFunc("/legacy-sse", legacySSE.serveEvents)
+	mux.HandleFunc("/legacy-message", legacySSE.serveMessage)
 	mux.Handle("/", newStreamableHTTPHandler())
 	return mux
 }
@@ -181,17 +181,6 @@ type legacyErrorSSESession struct {
 type legacyErrorSSERequest struct {
 	ID     json.RawMessage `json:"id"`
 	Method string          `json:"method"`
-}
-
-func (h *legacyErrorSSEHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	switch r.URL.Path {
-	case "/legacy-sse":
-		h.serveEvents(w, r)
-	case "/legacy-message":
-		h.serveMessage(w, r)
-	default:
-		http.NotFound(w, r)
-	}
 }
 
 func (h *legacyErrorSSEHandler) serveEvents(w http.ResponseWriter, r *http.Request) {

--- a/local/agent-gateway/charts/test-backends/test-mcp-backend/main.go
+++ b/local/agent-gateway/charts/test-backends/test-mcp-backend/main.go
@@ -12,6 +12,8 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -61,8 +63,13 @@ func main() {
 
 func newHandler() http.Handler {
 	mux := http.NewServeMux()
+	legacySSE := &legacyErrorSSEHandler{
+		sessions: make(map[string]*legacyErrorSSESession),
+	}
 	mux.HandleFunc("/healthz", handleHealthz)
-	mux.Handle("/", newMCPHandler())
+	mux.Handle("/legacy-sse", legacySSE)
+	mux.Handle("/legacy-message", legacySSE)
+	mux.Handle("/", newStreamableHTTPHandler())
 	return mux
 }
 
@@ -70,7 +77,7 @@ func handleHealthz(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func newMCPHandler() http.Handler {
+func newStreamableHTTPHandler() http.Handler {
 	s := server.NewMCPServer(
 		backendID(),
 		"0.1.0",
@@ -158,6 +165,115 @@ func newMCPHandler() http.Handler {
 	)
 
 	return logMCPPosts(server.NewStreamableHTTPServer(s, server.WithStateLess(true)))
+}
+
+type legacyErrorSSEHandler struct {
+	nextID    atomic.Uint64
+	sessions  map[string]*legacyErrorSSESession
+	sessionsM sync.RWMutex
+}
+
+type legacyErrorSSESession struct {
+	events chan []byte
+	done   chan struct{}
+}
+
+type legacyErrorSSERequest struct {
+	ID     json.RawMessage `json:"id"`
+	Method string          `json:"method"`
+}
+
+func (h *legacyErrorSSEHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/legacy-sse":
+		h.serveEvents(w, r)
+	case "/legacy-message":
+		h.serveMessage(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (h *legacyErrorSSEHandler) serveEvents(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	sessionID := fmt.Sprint(h.nextID.Add(1))
+	session := &legacyErrorSSESession{
+		events: make(chan []byte, 8),
+		done:   make(chan struct{}),
+	}
+	h.sessionsM.Lock()
+	h.sessions[sessionID] = session
+	h.sessionsM.Unlock()
+	defer func() {
+		h.sessionsM.Lock()
+		delete(h.sessions, sessionID)
+		close(session.done)
+		h.sessionsM.Unlock()
+	}()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	fmt.Fprintf(w, "event: endpoint\ndata: /legacy-message?sessionId=%s\r\n\r\n", sessionID)
+	flusher.Flush()
+
+	for {
+		select {
+		case event := <-session.events:
+			fmt.Fprintf(w, "event: message\ndata: %s\r\n\r\n", event)
+			flusher.Flush()
+		case <-r.Context().Done():
+			return
+		}
+	}
+}
+
+func (h *legacyErrorSSEHandler) serveMessage(w http.ResponseWriter, r *http.Request) {
+	h.sessionsM.RLock()
+	session, ok := h.sessions[r.URL.Query().Get("sessionId")]
+	h.sessionsM.RUnlock()
+	if !ok {
+		http.Error(w, "unknown session", http.StatusBadRequest)
+		return
+	}
+	var req legacyErrorSSERequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON-RPC request", http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+	if len(req.ID) == 0 || string(req.ID) == "null" {
+		return
+	}
+
+	response := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      req.ID,
+	}
+	switch req.Method {
+	case "initialize":
+		response["result"] = map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{"tools": map[string]any{}},
+			"serverInfo":      map[string]string{"name": backendID() + "-legacy-sse", "version": "0.1.0"},
+		}
+	case "tools/list":
+		response["result"] = map[string]any{"tools": []any{}}
+	default:
+		response["error"] = map[string]any{"code": -32601, "message": "method not found: " + req.Method}
+	}
+	event, err := json.Marshal(response)
+	if err != nil {
+		return
+	}
+	select {
+	case session.events <- event:
+	case <-session.done:
+	case <-r.Context().Done():
+	}
 }
 
 func logMCPPosts(next http.Handler) http.Handler {

--- a/local/agent-gateway/charts/test-backends/values.yaml
+++ b/local/agent-gateway/charts/test-backends/values.yaml
@@ -14,6 +14,9 @@ backends:
   - name: mcp-backend-b
     instance: backend-b
     replicas: 1
+  - name: legacy-sse
+    instance: legacy-sse
+    replicas: 1
 
 networkPolicy:
   enabled: true

--- a/local/agent-gateway/skaffold.infra.yaml
+++ b/local/agent-gateway/skaffold.infra.yaml
@@ -23,7 +23,7 @@ deploy:
       - --timeout=5m
     releases:
     - name: agentgateway-crds
-      chartPath: ../../.cache/helm/agentgateway-crds-v1.3.1.tgz
+      chartPath: ../../.cache/helm/agentgateway-crds-v1.4.1.tgz
       namespace: agentgateway-system
       createNamespace: true
       skipBuildDependencies: true

--- a/local/agent-gateway/tests/functional/agentgateway_regression_test.go
+++ b/local/agent-gateway/tests/functional/agentgateway_regression_test.go
@@ -1,0 +1,177 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package functional
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/dsx-exchange/local/agent-gateway/tests/functional/internal/runner"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestLegacySSEErrorDoesNotBlockPromptDiscovery(t *testing.T) {
+	runner.ParallelReadOnly(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	s := runner.NewSession(t, tenantAUnlimited)
+	t.Cleanup(s.Close)
+
+	if _, err := s.Client.ListPrompts(ctx, mcp.ListPromptsRequest{}); err != nil {
+		t.Fatalf("prompts/list with unsupported legacy SSE upstream: %v", err)
+	}
+}
+
+func TestLegacyInitializedRequestKeepsInternalError(t *testing.T) {
+	runner.ParallelReadOnly(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	token, sid := initSession(t, ctx, tenantAUnlimited)
+
+	resp := postSessionMCP(t, ctx, token, sid, []byte(
+		`{"jsonrpc":"2.0","id":"invalid-initialized-request","method":"notifications/initialized"}`,
+	))
+	code, _, ok := runner.JSONRPCError(resp.Body)
+	// Agentgateway preserves the pre-1.4 error contract for session-based clients.
+	if resp.Status != http.StatusInternalServerError || !ok || code != -32603 {
+		t.Fatalf("legacy initialized request = HTTP %d JSON-RPC %d (body: %s), want 500/-32603", resp.Status, code, resp.Body)
+	}
+
+	requireMCPListSuccess(t, postSessionMCP(t, ctx, token, sid, []byte(
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`,
+	)))
+}
+
+func TestLegacyUnknownTargetRequestsKeepInternalErrors(t *testing.T) {
+	runner.ParallelReadOnly(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	token, sid := initSession(t, ctx, tenantAUnlimited)
+
+	for name, body := range map[string]string{
+		"tool":     `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"does-not-exist","arguments":{}}}`,
+		"resource": `{"jsonrpc":"2.0","id":4,"method":"resources/read","params":{"uri":"does-not-exist+dsx://fixture/static"}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			resp := postSessionMCP(t, ctx, token, sid, []byte(body))
+			code, _, ok := runner.JSONRPCError(resp.Body)
+			// v1.4.x reclassifies stateless requests only; legacy sessions retain 500/-32603.
+			if resp.Status != http.StatusInternalServerError || !ok || code != -32603 {
+				t.Fatalf("legacy unknown %s = HTTP %d JSON-RPC %d (body: %s), want 500/-32603", name, resp.Status, code, resp.Body)
+			}
+		})
+	}
+}
+
+func TestModernStatelessClientDiscoversTools(t *testing.T) {
+	runner.ParallelReadOnly(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	token := runner.MintToken(t, tenantAUnlimited)
+
+	resp := postModernMCP(t, ctx, token, 1, "tools/list", "", map[string]any{})
+	requireMCPListSuccess(t, resp)
+	if sid := resp.Header.Get("Mcp-Session-Id"); sid != "" {
+		t.Fatalf("modern tools/list returned legacy session ID %q", sid)
+	}
+}
+
+func TestModernInitializedRequestReturnsMethodNotFound(t *testing.T) {
+	runner.ParallelReadOnly(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	token := runner.MintToken(t, tenantAUnlimited)
+
+	resp := postModernMCP(t, ctx, token, 2, "notifications/initialized", "", map[string]any{})
+	code, _, ok := runner.JSONRPCError(resp.Body)
+	if resp.Status != http.StatusNotFound || !ok || code != -32601 {
+		t.Fatalf("modern initialized request = HTTP %d JSON-RPC %d (body: %s), want 404/-32601", resp.Status, code, resp.Body)
+	}
+}
+
+func TestModernUnknownTargetRequestsReturnClientErrors(t *testing.T) {
+	runner.ParallelReadOnly(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	token := runner.MintToken(t, tenantAUnlimited)
+
+	for name, tc := range map[string]struct {
+		method string
+		target string
+		params map[string]any
+	}{
+		"tool": {
+			method: "tools/call",
+			target: "does-not-exist",
+			params: map[string]any{"name": "does-not-exist", "arguments": map[string]any{}},
+		},
+		"resource": {
+			method: "resources/read",
+			target: "does-not-exist+dsx://fixture/static",
+			params: map[string]any{"uri": "does-not-exist+dsx://fixture/static"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resp := postModernMCP(t, ctx, token, 3, tc.method, tc.target, tc.params)
+			code, _, ok := runner.JSONRPCError(resp.Body)
+			if resp.Status != http.StatusBadRequest || !ok || code != -32602 {
+				t.Fatalf("modern unknown %s = HTTP %d JSON-RPC %d (body: %s), want 400/-32602", name, resp.Status, code, resp.Body)
+			}
+		})
+	}
+}
+
+func postModernMCP(
+	t *testing.T,
+	ctx context.Context,
+	bearer string,
+	id int,
+	method string,
+	name string,
+	params map[string]any,
+) runner.RawResponse {
+	t.Helper()
+	params["_meta"] = map[string]any{
+		"io.modelcontextprotocol/protocolVersion":    "2026-07-28",
+		"io.modelcontextprotocol/clientInfo":         map[string]any{"name": "dsx-exchange-tests", "version": "1"},
+		"io.modelcontextprotocol/clientCapabilities": map[string]any{},
+	}
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"method":  method,
+		"params":  params,
+	})
+	if err != nil {
+		t.Fatalf("marshal modern MCP request: %v", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, runner.GatewayURL(t), bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build modern MCP request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Mcp-Protocol-Version", "2026-07-28")
+	req.Header.Set("Mcp-Method", method)
+	if name != "" {
+		req.Header.Set("Mcp-Name", name)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST modern MCP request: %v", err)
+	}
+	_, responseBody := readAll(t, resp)
+	return runner.RawResponse{Status: resp.StatusCode, Body: responseBody, Header: resp.Header.Clone()}
+}

--- a/local/agent-gateway/tests/functional/resources_test.go
+++ b/local/agent-gateway/tests/functional/resources_test.go
@@ -5,7 +5,6 @@ package functional
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -14,7 +13,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
-func TestResourcesListUnsupportedWithBridgeTarget(t *testing.T) {
+func TestResourcesListIgnoresUnsupportedBridgeTarget(t *testing.T) {
 	runner.ParallelReadOnly(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -23,17 +22,18 @@ func TestResourcesListUnsupportedWithBridgeTarget(t *testing.T) {
 	s := runner.NewSession(t, tenantAUnlimited)
 	t.Cleanup(s.Close)
 
-	_, err := s.Client.ListResources(ctx, mcp.ListResourcesRequest{})
-	if err == nil {
-		t.Fatalf("resources/list unexpectedly succeeded on the bridge-participating DSX Agent Gateway")
+	result, err := s.Client.ListResources(ctx, mcp.ListResourcesRequest{})
+	if err != nil {
+		t.Fatalf("resources/list with unsupported bridge target: %v", err)
 	}
-	msg := strings.ToLower(err.Error())
-	if !errors.Is(err, mcp.ErrMethodNotFound) ||
-		!strings.Contains(msg, "resources/list") ||
-		!strings.Contains(msg, "not supported") ||
-		!strings.Contains(msg, "stateless bridge") {
-		t.Fatalf("resources/list error = %q, want stateless bridge unsupported rejection", err)
+	// Agentgateway v1.4 keeps successful resource catalogs when another target
+	// rejects resources/list, so the stateless bridge no longer fails fanout.
+	for _, resource := range result.Resources {
+		if resource.URI == "mcp-backend-a-mcp+dsx://fixture/static" {
+			return
+		}
 	}
+	t.Fatalf("resources/list = %#v, want backend resource", result.Resources)
 }
 
 func TestResourcesReadWithMultiplexing(t *testing.T) {
@@ -78,7 +78,7 @@ func TestResourcesReadUnknownResourceWithMultiplexing(t *testing.T) {
 	}
 }
 
-func TestResourcesTemplatesListUnsupportedWithBridgeTarget(t *testing.T) {
+func TestResourceTemplatesListIgnoresUnsupportedBridgeTarget(t *testing.T) {
 	runner.ParallelReadOnly(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -86,17 +86,19 @@ func TestResourcesTemplatesListUnsupportedWithBridgeTarget(t *testing.T) {
 	s := runner.NewSession(t, tenantAUnlimited)
 	t.Cleanup(s.Close)
 
-	_, err := s.Client.ListResourceTemplates(ctx, mcp.ListResourceTemplatesRequest{})
-	if err == nil {
-		t.Fatal("resources/templates/list unexpectedly succeeded with a bridge target")
+	result, err := s.Client.ListResourceTemplates(ctx, mcp.ListResourceTemplatesRequest{})
+	if err != nil {
+		t.Fatalf("resources/templates/list with unsupported bridge target: %v", err)
 	}
-	msg := strings.ToLower(err.Error())
-	if !errors.Is(err, mcp.ErrMethodNotFound) ||
-		!strings.Contains(msg, "resources/templates/list") ||
-		!strings.Contains(msg, "not supported") ||
-		!strings.Contains(msg, "stateless bridge") {
-		t.Fatalf("resources/templates/list error = %q, want stateless bridge unsupported rejection", err)
+	// Agentgateway v1.4 keeps successful template catalogs when another target
+	// rejects resources/templates/list, matching resources/list fanout.
+	for _, template := range result.ResourceTemplates {
+		if template.URITemplate != nil &&
+			template.URITemplate.Raw() == "mcp-backend-a-mcp+dsx://fixture/{name}" {
+			return
+		}
 	}
+	t.Fatalf("resources/templates/list = %#v, want backend resource template", result.ResourceTemplates)
 }
 
 func TestResourceReferenceCompletionUnsupportedAtGateway(t *testing.T) {

--- a/local/agent-gateway/values/values.local-static.yaml
+++ b/local/agent-gateway/values/values.local-static.yaml
@@ -9,5 +9,5 @@ upstreams:
     requestTimeout: 10s
   legacy-sse:
     mode: static
-    address: http://mcp-backend-a.csc-mcp-backends.svc:3001/legacy-sse
+    address: http://legacy-sse.csc-mcp-backends.svc:3001/legacy-sse
     protocol: SSE

--- a/local/agent-gateway/values/values.local-static.yaml
+++ b/local/agent-gateway/values/values.local-static.yaml
@@ -7,3 +7,7 @@ upstreams:
     mode: static
     address: http://mcp-backend-b.csc-mcp-backends.svc:3001/mcp
     requestTimeout: 10s
+  legacy-sse:
+    mode: static
+    address: http://mcp-backend-a.csc-mcp-backends.svc:3001/legacy-sse
+    protocol: SSE

--- a/local/scripts/prepare-dependencies.sh
+++ b/local/scripts/prepare-dependencies.sh
@@ -65,12 +65,12 @@ if [[ -d "${repo_root}/deploy/dsx-agent-gateway" ]]; then
   "${cache_chart}" nats-2.14.2.tgz nats 2.14.2 https://nats-io.github.io/k8s/helm/charts/
   "${cache_chart}" opentelemetry-collector-0.164.1.tgz opentelemetry-collector 0.164.1 https://open-telemetry.github.io/opentelemetry-helm-charts
   "${cache_chart}" opentelemetry-operator-0.119.0.tgz opentelemetry-operator 0.119.0 https://open-telemetry.github.io/opentelemetry-helm-charts
-  "${cache_chart}" agentgateway-crds-v1.3.1.tgz oci://cr.agentgateway.dev/charts/agentgateway-crds v1.3.1
-  "${cache_chart}" agentgateway-v1.3.1.tgz oci://cr.agentgateway.dev/charts/agentgateway v1.3.1
+  "${cache_chart}" agentgateway-crds-v1.4.1.tgz oci://cr.agentgateway.dev/charts/agentgateway-crds v1.4.1
+  "${cache_chart}" agentgateway-v1.4.1.tgz oci://cr.agentgateway.dev/charts/agentgateway v1.4.1
   "${cache_chart}" valkey-0.9.4.tgz valkey 0.9.4 https://valkey-io.github.io/valkey-helm
 
   mkdir -p "${gateway_charts}"
-  for archive in agentgateway-v1.3.1.tgz valkey-0.9.4.tgz; do
+  for archive in agentgateway-v1.4.1.tgz valkey-0.9.4.tgz; do
     cmp -s "${cache_dir}/${archive}" "${gateway_charts}/${archive}" ||
       cp "${cache_dir}/${archive}" "${gateway_charts}/${archive}"
   done


### PR DESCRIPTION
## Summary

- update Agentgateway controller, dataplane, chart, and CRDs to v1.4.1
- retain the existing Gateway API v1.5.1 and TCPRoute v1alpha2 deployment contract
- add regression coverage for legacy SSE fanout and modern stateless MCP clients
- document intentional legacy stateful error responses
- attribute gateway behavior to Agentgateway and DSX-specific routing to `dsx-agentgateway-bridge`

## Changelog and compatibility review

Agentgateway v1.4.1 supports the repository's existing Gateway API v1.5.1
deployment. Gateway API manifests, checksums, route API versions, and the
Envoy Gateway compatibility contract remain unchanged. Other v1.4 changes do
not require DSX configuration updates.

## Red to green

Against Agentgateway v1.3.1:

- legacy `prompts/list` timed out through an SSE upstream
- all new stateless 2026 client cases failed with an invalid protocol-version
  response

Against Agentgateway v1.4.1, all six focused regressions pass:

```text
PASS
ok github.com/NVIDIA/dsx-exchange/local/agent-gateway/tests/functional 0.601s
```

Additional validation:

- `go -C local/agent-gateway/tests/functional test -run '^$' ./...`
- `git diff --check`

Full `make test` delegated to CI as requested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added legacy SSE MCP session support, including initialization, tool discovery, validation, and error handling.
  * Added configuration for legacy SSE backends.

* **Bug Fixes**
  * Preserved backend resources when unsupported bridge targets reject fanout requests.

* **Updates**
  * Upgraded Agentgateway components to version 1.4.1.
  * Updated deployment documentation, terminology, installation guidance, and observability references.

* **Tests**
  * Added regression coverage for legacy SSE and modern MCP request scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->