### PR TITLE
feat(observability): add service dashboards and alerts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,12 +25,13 @@ In the sandbox this has failed with Docker buildx permission errors and
 host-side networking timeouts. Use the root Make targets with unsandboxed
 execution, for example `make local-up` and `make test`.
 
-For local deploy and infrastructure scripts, prefer direct validation over
-meta-level tests. Do not add shell tests whose main purpose is to inspect deploy
-script text or mock/assert exact command sequences such as Helm repo updates,
-Kind image loads, timeouts, or Gateway YAML fields. Validate these changes with
-syntax checks, Helm rendering/linting when applicable, and the real affected
-local Make target outside the sandbox.
+For local deployment and infrastructure changes, prefer direct validation over
+meta-level tests. Do not add tests in any language whose primary purpose is to
+inspect source text, rendered manifests, deployed resource fields, or exact
+command sequences. This includes Helm repo updates, Kind image loads, timeout
+values, and Gateway or monitor YAML fields. Validate changes with syntax checks,
+Helm rendering or linting when applicable, and the real affected local Make
+target and behavior outside the sandbox.
 
 ## Skaffold validation checklist
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -487,6 +487,36 @@ centralized monitoring of both clusters.
 
 **Prerequisite:** Prometheus Operator must be installed for the ServiceMonitor and PodMonitor CRDs. Install via `kube-prometheus-stack` Helm chart or equivalent.
 
+### Dashboard and alerts
+
+The Surveyor dashboard and NATS alert rules are disabled by default. Enable
+either resource in any release that should own it. The chart does not install
+Grafana or configure dashboard or `PrometheusRule` discovery.
+
+The dashboard is the unchanged NATS Surveyor v0.9.7 dashboard. Supply labels
+and annotations that match the target Grafana sidecar or operator.
+
+```yaml
+global:
+  eventBus:
+    alerts:
+      enabled: true
+      team: <alert-owner>
+
+surveyor:
+  grafanaDashboard:
+    enabled: true
+    labels:
+      <dashboard-discovery-label>: <dashboard-discovery-value>
+    annotations:
+      <dashboard-folder-annotation>: <dashboard-folder>
+```
+
+Alert rules cover missing or incomplete Surveyor data, reconnects, slow
+consumers, memory pressure, and route backlog. The configured `team` is added
+to every alert. Route alert notifications and select `PrometheusRule`
+resources in the platform observability configuration.
+
 ### Surveyor Configuration
 
 Surveyor is configured via the `surveyor` section in values:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -489,14 +489,14 @@ centralized monitoring of both clusters.
 
 ### Dashboard and alerts
 
-The Surveyor dashboard and NATS alert rules are disabled by default. Enable
-them independently through deployment values. Set dashboard labels to match
-Grafana discovery. Enable alerts where Prometheus discovers `PrometheusRule`
-resources. The chart does not install either system or configure its discovery
-selectors.
+Both resources default off. Enable the dashboard with
+`surveyor.grafanaDashboard.enabled` and alerts with
+`global.eventBus.alerts.enabled`. Dashboard labels must match Grafana discovery.
+Prometheus must discover rules in the release namespace. The chart installs
+neither system.
 
-The dashboard is the unchanged NATS Surveyor v0.9.7 dashboard. Supply labels
-and annotations that match the target Grafana sidecar or operator.
+The dashboard is unchanged from NATS Surveyor v0.9.7. Labels and annotations
+are passed to its ConfigMap.
 
 ```yaml
 global:
@@ -516,8 +516,7 @@ surveyor:
 
 Alert rules cover missing or incomplete Surveyor data, reconnects, slow
 consumers, memory pressure, and route backlog. The configured `team` is added
-to every alert. Route alert notifications and select `PrometheusRule`
-resources in the platform observability configuration.
+to every alert.
 
 ### Surveyor Configuration
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -490,8 +490,10 @@ centralized monitoring of both clusters.
 ### Dashboard and alerts
 
 The Surveyor dashboard and NATS alert rules are disabled by default. Enable
-either resource in any release that should own it. The chart does not install
-Grafana or configure dashboard or `PrometheusRule` discovery.
+them independently through deployment values. Set dashboard labels to match
+Grafana discovery. Enable alerts where Prometheus discovers `PrometheusRule`
+resources. The chart does not install either system or configure its discovery
+selectors.
 
 The dashboard is the unchanged NATS Surveyor v0.9.7 dashboard. Supply labels
 and annotations that match the target Grafana sidecar or operator.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -489,14 +489,7 @@ centralized monitoring of both clusters.
 
 ### Dashboard and alerts
 
-Both resources default off. Enable the dashboard with
-`surveyor.grafanaDashboard.enabled` and alerts with
-`global.eventBus.alerts.enabled`. Dashboard labels must match Grafana discovery.
-Prometheus must discover rules in the release namespace. The chart installs
-neither system.
-
-The dashboard is unchanged from NATS Surveyor v0.9.7. Labels and annotations
-are passed to its ConfigMap.
+Both default off:
 
 ```yaml
 global:
@@ -504,19 +497,19 @@ global:
     alerts:
       enabled: true
       team: <alert-owner>
-
-surveyor:
-  grafanaDashboard:
-    enabled: true
-    labels:
-      <dashboard-discovery-label>: <dashboard-discovery-value>
-    annotations:
-      <dashboard-folder-annotation>: <dashboard-folder>
+    grafanaDashboard:
+      enabled: true
+      labels:
+        <dashboard-discovery-label>: <dashboard-discovery-value>
+      annotations:
+        <dashboard-folder-annotation>: <dashboard-folder>
 ```
 
-Alert rules cover missing or incomplete Surveyor data, reconnects, slow
-consumers, memory pressure, and route backlog. The configured `team` is added
-to every alert.
+The dashboard is unchanged from NATS Surveyor v0.9.7. ConfigMap labels and
+annotations control Grafana discovery. Prometheus must discover rules in the
+release namespace. Rules detect missing or incomplete Surveyor data,
+reconnects, slow consumers, memory pressure, and route backlog. `team` labels
+every alert.
 
 ### Surveyor Configuration
 

--- a/deploy/dsx-agent-gateway/README.md
+++ b/deploy/dsx-agent-gateway/README.md
@@ -198,7 +198,7 @@ examples inline. Additional native settings passed to the `agentgateway` and
 | `rateLimit` | Tenant limits and the chart-owned rate-limit service |
 | `valkey` | Bundled or external Valkey storage |
 | `bridge` | Optional hub or leaf bridge and its NATS connection |
-| `observability` | Prometheus metrics discovery and OTLP tracing |
+| `observability` | Prometheus metrics discovery, alerts, and OTLP tracing |
 
 For agentgateway concepts, use the
 [agentgateway Kubernetes documentation](https://agentgateway.dev/docs/kubernetes/).
@@ -250,6 +250,37 @@ valkey:
   metrics:
     enabled: true # Upstream Valkey exporter sidecar and ServiceMonitor.
 ```
+
+### Dashboard and alerts
+
+The dashboard and alert rules are disabled by default. Enable either resource
+in any release that should own it. The chart does not install Grafana or
+configure dashboard or `PrometheusRule` discovery.
+
+The dashboard comes from the pinned Agent Gateway chart. Supply labels that
+match the target Grafana sidecar or operator. Keep metrics enabled so its
+Prometheus queries have data.
+
+```yaml
+agentgateway:
+  monitoring:
+    grafanaDashboard:
+      enabled: true
+      labels:
+        <dashboard-discovery-label>: <dashboard-discovery-value>
+
+observability:
+  alerts:
+    enabled: true
+    team: <alert-owner>
+  metrics:
+    enabled: true
+```
+
+Alert rules cover missing proxy and controller metrics, configuration sync,
+5xx rate, p99 latency, and xDS authorization failures. The configured `team`
+is added to every alert. Route alert notifications and select
+`PrometheusRule` resources in the platform observability configuration.
 
 | Component | Metrics source | Tracing source | Configuration source |
 |---|---|---|---|

--- a/deploy/dsx-agent-gateway/README.md
+++ b/deploy/dsx-agent-gateway/README.md
@@ -253,14 +253,14 @@ valkey:
 
 ### Dashboard and alerts
 
-The dashboard and alert rules are disabled by default. Enable them independently
-through deployment values. Set dashboard labels to match Grafana discovery.
-Enable alerts where Prometheus discovers `PrometheusRule` resources. The chart
-does not install either system or configure its discovery selectors.
+Both resources default off. Enable the dashboard with
+`agentgateway.monitoring.grafanaDashboard.enabled` and alerts with
+`observability.alerts.enabled`. Dashboard labels must match Grafana discovery.
+Prometheus must discover rules in the release namespace. The chart installs
+neither system.
 
-The dashboard comes from the pinned Agent Gateway chart. Supply labels that
-match the target Grafana sidecar or operator. Keep metrics enabled so its
-Prometheus queries have data.
+The dashboard comes from the pinned Agent Gateway chart. Keep metrics enabled
+so its Prometheus queries have data.
 
 ```yaml
 agentgateway:
@@ -280,8 +280,7 @@ observability:
 
 Alert rules cover missing proxy and controller metrics, configuration sync,
 5xx rate, p99 latency, and xDS authorization failures. The configured `team`
-is added to every alert. Route alert notifications and select
-`PrometheusRule` resources in the platform observability configuration.
+is added to every alert.
 
 | Component | Metrics source | Tracing source | Configuration source |
 |---|---|---|---|

--- a/deploy/dsx-agent-gateway/README.md
+++ b/deploy/dsx-agent-gateway/README.md
@@ -253,9 +253,10 @@ valkey:
 
 ### Dashboard and alerts
 
-The dashboard and alert rules are disabled by default. Enable either resource
-in any release that should own it. The chart does not install Grafana or
-configure dashboard or `PrometheusRule` discovery.
+The dashboard and alert rules are disabled by default. Enable them independently
+through deployment values. Set dashboard labels to match Grafana discovery.
+Enable alerts where Prometheus discovers `PrometheusRule` resources. The chart
+does not install either system or configure its discovery selectors.
 
 The dashboard comes from the pinned Agent Gateway chart. Supply labels that
 match the target Grafana sidecar or operator. Keep metrics enabled so its

--- a/deploy/dsx-agent-gateway/README.md
+++ b/deploy/dsx-agent-gateway/README.md
@@ -253,14 +253,7 @@ valkey:
 
 ### Dashboard and alerts
 
-Both resources default off. Enable the dashboard with
-`agentgateway.monitoring.grafanaDashboard.enabled` and alerts with
-`observability.alerts.enabled`. Dashboard labels must match Grafana discovery.
-Prometheus must discover rules in the release namespace. The chart installs
-neither system.
-
-The dashboard comes from the pinned Agent Gateway chart. Keep metrics enabled
-so its Prometheus queries have data.
+Both default off:
 
 ```yaml
 agentgateway:
@@ -278,9 +271,11 @@ observability:
     enabled: true
 ```
 
-Alert rules cover missing proxy and controller metrics, configuration sync,
-5xx rate, p99 latency, and xDS authorization failures. The configured `team`
-is added to every alert.
+The dashboard comes from the pinned Agent Gateway chart and requires metrics.
+Labels must match Grafana discovery. Prometheus must discover rules in the
+release namespace. Rules detect missing metrics, configuration sync failures,
+high 5xx rate or p99 latency, and xDS authorization failures. `team` labels
+every alert.
 
 | Component | Metrics source | Tracing source | Configuration source |
 |---|---|---|---|

--- a/deploy/dsx-agent-gateway/templates/monitoring.yaml
+++ b/deploy/dsx-agent-gateway/templates/monitoring.yaml
@@ -18,6 +18,10 @@ spec:
       gateway.networking.k8s.io/gateway-name: {{ include "dsxAgentGateway.gatewayName" . }}
   podMetricsEndpoints:
     {{- include "dsxAgentGateway.metricsEndpoint" (dict "root" . "port" "metrics") | nindent 4 }}
+      relabelings:
+        # Required by the upstream Agent Gateway dashboard's gateway selector.
+        - sourceLabels: [__meta_kubernetes_pod_label_gateway_networking_k8s_io_gateway_name]
+          targetLabel: gateway_networking_k8s_io_gateway_name
 {{- if .Values.agentgateway.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1

--- a/deploy/dsx-agent-gateway/templates/prometheus-rule.yaml
+++ b/deploy/dsx-agent-gateway/templates/prometheus-rule.yaml
@@ -24,7 +24,6 @@ spec:
           annotations:
             summary: Agent Gateway proxy metrics are unavailable.
             description: No Agent Gateway proxy metrics have been observed for 10 minutes.
-            runbook_url: {{ .Values.observability.alerts.runbookUrl | quote }}
         - alert: AgentGatewayControllerMetricsAbsent
           expr: absent(agentgateway_controller_build_info{namespace="{{ .Release.Namespace }}"})
           for: 10m
@@ -34,7 +33,6 @@ spec:
           annotations:
             summary: Agent Gateway controller metrics are unavailable.
             description: No Agent Gateway controller metrics have been observed for 10 minutes.
-            runbook_url: {{ .Values.observability.alerts.runbookUrl | quote }}
         - alert: AgentGatewayConfigNotSynchronized
           expr: agentgateway_config_synchronized{namespace="{{ .Release.Namespace }}"} == 0
           for: 5m
@@ -44,7 +42,6 @@ spec:
           annotations:
             summary: An Agent Gateway proxy has not synchronized configuration.
             description: An Agent Gateway proxy has reported unsynchronized configuration for 5 minutes.
-            runbook_url: {{ .Values.observability.alerts.runbookUrl | quote }}
         - alert: AgentGatewayHighErrorRate
           expr: |
             sum by (namespace, gateway) (rate(agentgateway_requests_total{namespace="{{ .Release.Namespace }}",status=~"5.."}[5m]))
@@ -57,7 +54,6 @@ spec:
           annotations:
             summary: Agent Gateway 5xx error rate is above 5 percent.
             description: The 5xx response rate has remained above 5 percent for 10 minutes.
-            runbook_url: {{ .Values.observability.alerts.runbookUrl | quote }}
         - alert: AgentGatewayHighP99Latency
           expr: |
             histogram_quantile(0.99, sum by (le, namespace, gateway) (rate(agentgateway_request_duration_seconds_bucket{namespace="{{ .Release.Namespace }}"}[5m]))) > 5
@@ -69,7 +65,6 @@ spec:
           annotations:
             summary: Agent Gateway p99 request latency is above 5 seconds.
             description: The p99 request latency has remained above 5 seconds for 10 minutes.
-            runbook_url: {{ .Values.observability.alerts.runbookUrl | quote }}
         - alert: AgentGatewayXDSAuthorizationFailures
           expr: sum by (namespace) (increase(agentgateway_xds_auth_rq_failure_total{namespace="{{ .Release.Namespace }}"}[5m])) > 0
           for: 5m
@@ -79,5 +74,4 @@ spec:
           annotations:
             summary: Agent Gateway rejected xDS authorization requests.
             description: The Agent Gateway controller reported xDS authorization failures.
-            runbook_url: {{ .Values.observability.alerts.runbookUrl | quote }}
 {{- end }}

--- a/deploy/dsx-agent-gateway/templates/prometheus-rule.yaml
+++ b/deploy/dsx-agent-gateway/templates/prometheus-rule.yaml
@@ -1,0 +1,91 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.observability.alerts.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Release.Name }}-alerts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: dsx-agent-gateway
+    app.kubernetes.io/component: alerting
+spec:
+  groups:
+    - name: dsx-agent-gateway.rules
+      interval: 30s
+      rules:
+        - alert: AgentGatewayProxyMetricsAbsent
+          expr: absent(agentgateway_build_info{namespace="{{ .Release.Namespace }}"}) == 1
+          for: 10m
+          labels:
+            severity: critical
+            team: dsx
+          annotations:
+            summary: Agent Gateway proxy metrics are unavailable.
+            description: No Agent Gateway proxy metrics have been observed for 10 minutes.
+            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/dsx-agent-gateway/README.md
+        - alert: AgentGatewayControllerMetricsAbsent
+          expr: absent(agentgateway_controller_build_info{namespace="{{ .Release.Namespace }}"}) == 1
+          for: 10m
+          labels:
+            severity: critical
+            team: dsx
+          annotations:
+            summary: Agent Gateway controller metrics are unavailable.
+            description: No Agent Gateway controller metrics have been observed for 10 minutes.
+            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/dsx-agent-gateway/README.md
+        - alert: AgentGatewayConfigNotSynchronized
+          expr: agentgateway_config_synchronized{namespace="{{ .Release.Namespace }}"} == 0
+          for: 5m
+          labels:
+            severity: critical
+            team: dsx
+          annotations:
+            summary: An Agent Gateway proxy has not synchronized configuration.
+            description: An Agent Gateway proxy has reported unsynchronized configuration for 5 minutes.
+            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/dsx-agent-gateway/README.md
+        - alert: AgentGatewayHighErrorRate
+          expr: |
+            sum by (gateway) (rate(agentgateway_requests_total{namespace="{{ .Release.Namespace }}",status=~"5.."}[5m]))
+              /
+            sum by (gateway) (rate(agentgateway_requests_total{namespace="{{ .Release.Namespace }}"}[5m]))
+              > 0.05
+          for: 10m
+          labels:
+            severity: warning
+            team: dsx
+          annotations:
+            summary: Agent Gateway 5xx error rate is above 5 percent.
+            description: The 5xx response rate has remained above 5 percent for 10 minutes.
+            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/dsx-agent-gateway/README.md
+        - alert: AgentGatewayHighP99Latency
+          expr: |
+            histogram_quantile(
+              0.99,
+              sum by (le, gateway) (rate(agentgateway_request_duration_seconds_bucket{namespace="{{ .Release.Namespace }}"}[5m]))
+            ) > 5
+          for: 10m
+          labels:
+            severity: warning
+            team: dsx
+          annotations:
+            summary: Agent Gateway p99 request latency is above 5 seconds.
+            description: The p99 request latency has remained above 5 seconds for 10 minutes.
+            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/dsx-agent-gateway/README.md
+        - alert: AgentGatewayXDSAuthorizationFailures
+          expr: |
+            sum by (namespace) (
+              increase(agentgateway_xds_auth_rq_total{namespace="{{ .Release.Namespace }}"}[5m])
+                -
+              increase(agentgateway_xds_auth_rq_success_total{namespace="{{ .Release.Namespace }}"}[5m])
+            ) > 0
+          for: 5m
+          labels:
+            severity: warning
+            team: dsx
+          annotations:
+            summary: Agent Gateway rejected xDS authorization requests.
+            description: The Agent Gateway controller reported xDS authorization failures.
+            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/dsx-agent-gateway/README.md
+{{- end }}

--- a/deploy/dsx-agent-gateway/templates/prometheus-rule.yaml
+++ b/deploy/dsx-agent-gateway/templates/prometheus-rule.yaml
@@ -46,7 +46,7 @@ spec:
             description: An Agent Gateway proxy has reported unsynchronized configuration for 5 minutes.
             runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/dsx-agent-gateway/README.md
         - alert: AgentGatewayHighErrorRate
-          expr: sum by (gateway) (rate(agentgateway_requests_total{namespace="{{ .Release.Namespace }}",status=~"5.."}[5m])) / sum by (gateway) (rate(agentgateway_requests_total{namespace="{{ .Release.Namespace }}"}[5m])) > 0.05
+          expr: sum by (namespace, gateway) (rate(agentgateway_requests_total{namespace="{{ .Release.Namespace }}",status=~"5.."}[5m])) / sum by (namespace, gateway) (rate(agentgateway_requests_total{namespace="{{ .Release.Namespace }}"}[5m])) > 0.05
           for: 10m
           labels:
             severity: warning
@@ -56,7 +56,7 @@ spec:
             description: The 5xx response rate has remained above 5 percent for 10 minutes.
             runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/dsx-agent-gateway/README.md
         - alert: AgentGatewayHighP99Latency
-          expr: histogram_quantile(0.99, sum by (le, gateway) (rate(agentgateway_request_duration_seconds_bucket{namespace="{{ .Release.Namespace }}"}[5m]))) > 5
+          expr: histogram_quantile(0.99, sum by (le, namespace, gateway) (rate(agentgateway_request_duration_seconds_bucket{namespace="{{ .Release.Namespace }}"}[5m]))) > 5
           for: 10m
           labels:
             severity: warning

--- a/deploy/dsx-agent-gateway/templates/prometheus-rule.yaml
+++ b/deploy/dsx-agent-gateway/templates/prometheus-rule.yaml
@@ -1,7 +1,9 @@
 # Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.observability.alerts.enabled }}
+{{- $observability := .Values.observability | default (dict) }}
+{{- $alerts := $observability.alerts | default (dict) }}
+{{- if ($alerts.enabled | default false) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/deploy/dsx-agent-gateway/templates/prometheus-rule.yaml
+++ b/deploy/dsx-agent-gateway/templates/prometheus-rule.yaml
@@ -20,59 +20,64 @@ spec:
           for: 10m
           labels:
             severity: critical
-            team: dsx
+            team: {{ .Values.observability.alerts.team | quote }}
           annotations:
             summary: Agent Gateway proxy metrics are unavailable.
             description: No Agent Gateway proxy metrics have been observed for 10 minutes.
-            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/dsx-agent-gateway/README.md
+            runbook_url: {{ .Values.observability.alerts.runbookUrl | quote }}
         - alert: AgentGatewayControllerMetricsAbsent
           expr: absent(agentgateway_controller_build_info{namespace="{{ .Release.Namespace }}"})
           for: 10m
           labels:
             severity: critical
-            team: dsx
+            team: {{ .Values.observability.alerts.team | quote }}
           annotations:
             summary: Agent Gateway controller metrics are unavailable.
             description: No Agent Gateway controller metrics have been observed for 10 minutes.
-            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/dsx-agent-gateway/README.md
+            runbook_url: {{ .Values.observability.alerts.runbookUrl | quote }}
         - alert: AgentGatewayConfigNotSynchronized
           expr: agentgateway_config_synchronized{namespace="{{ .Release.Namespace }}"} == 0
           for: 5m
           labels:
             severity: critical
-            team: dsx
+            team: {{ .Values.observability.alerts.team | quote }}
           annotations:
             summary: An Agent Gateway proxy has not synchronized configuration.
             description: An Agent Gateway proxy has reported unsynchronized configuration for 5 minutes.
-            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/dsx-agent-gateway/README.md
+            runbook_url: {{ .Values.observability.alerts.runbookUrl | quote }}
         - alert: AgentGatewayHighErrorRate
-          expr: sum by (namespace, gateway) (rate(agentgateway_requests_total{namespace="{{ .Release.Namespace }}",status=~"5.."}[5m])) / sum by (namespace, gateway) (rate(agentgateway_requests_total{namespace="{{ .Release.Namespace }}"}[5m])) > 0.05
+          expr: |
+            sum by (namespace, gateway) (rate(agentgateway_requests_total{namespace="{{ .Release.Namespace }}",status=~"5.."}[5m]))
+              / sum by (namespace, gateway) (rate(agentgateway_requests_total{namespace="{{ .Release.Namespace }}"}[5m])) > 0.05
+            and sum by (namespace, gateway) (rate(agentgateway_requests_total{namespace="{{ .Release.Namespace }}"}[5m])) > 0.01
           for: 10m
           labels:
             severity: warning
-            team: dsx
+            team: {{ .Values.observability.alerts.team | quote }}
           annotations:
             summary: Agent Gateway 5xx error rate is above 5 percent.
             description: The 5xx response rate has remained above 5 percent for 10 minutes.
-            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/dsx-agent-gateway/README.md
+            runbook_url: {{ .Values.observability.alerts.runbookUrl | quote }}
         - alert: AgentGatewayHighP99Latency
-          expr: histogram_quantile(0.99, sum by (le, namespace, gateway) (rate(agentgateway_request_duration_seconds_bucket{namespace="{{ .Release.Namespace }}"}[5m]))) > 5
+          expr: |
+            histogram_quantile(0.99, sum by (le, namespace, gateway) (rate(agentgateway_request_duration_seconds_bucket{namespace="{{ .Release.Namespace }}"}[5m]))) > 5
+            and sum by (namespace, gateway) (rate(agentgateway_request_duration_seconds_count{namespace="{{ .Release.Namespace }}"}[5m])) > 0.01
           for: 10m
           labels:
             severity: warning
-            team: dsx
+            team: {{ .Values.observability.alerts.team | quote }}
           annotations:
             summary: Agent Gateway p99 request latency is above 5 seconds.
             description: The p99 request latency has remained above 5 seconds for 10 minutes.
-            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/dsx-agent-gateway/README.md
+            runbook_url: {{ .Values.observability.alerts.runbookUrl | quote }}
         - alert: AgentGatewayXDSAuthorizationFailures
           expr: sum by (namespace) (increase(agentgateway_xds_auth_rq_failure_total{namespace="{{ .Release.Namespace }}"}[5m])) > 0
           for: 5m
           labels:
             severity: warning
-            team: dsx
+            team: {{ .Values.observability.alerts.team | quote }}
           annotations:
             summary: Agent Gateway rejected xDS authorization requests.
             description: The Agent Gateway controller reported xDS authorization failures.
-            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/dsx-agent-gateway/README.md
+            runbook_url: {{ .Values.observability.alerts.runbookUrl | quote }}
 {{- end }}

--- a/deploy/dsx-agent-gateway/templates/prometheus-rule.yaml
+++ b/deploy/dsx-agent-gateway/templates/prometheus-rule.yaml
@@ -1,9 +1,7 @@
 # Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-{{- $observability := .Values.observability | default (dict) }}
-{{- $alerts := $observability.alerts | default (dict) }}
-{{- if ($alerts.enabled | default false) }}
+{{- if .Values.observability.alerts.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -18,7 +16,7 @@ spec:
       interval: 30s
       rules:
         - alert: AgentGatewayProxyMetricsAbsent
-          expr: absent(agentgateway_build_info{namespace="{{ .Release.Namespace }}"}) == 1
+          expr: absent(agentgateway_build_info{namespace="{{ .Release.Namespace }}"})
           for: 10m
           labels:
             severity: critical
@@ -28,7 +26,7 @@ spec:
             description: No Agent Gateway proxy metrics have been observed for 10 minutes.
             runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/dsx-agent-gateway/README.md
         - alert: AgentGatewayControllerMetricsAbsent
-          expr: absent(agentgateway_controller_build_info{namespace="{{ .Release.Namespace }}"}) == 1
+          expr: absent(agentgateway_controller_build_info{namespace="{{ .Release.Namespace }}"})
           for: 10m
           labels:
             severity: critical
@@ -48,11 +46,7 @@ spec:
             description: An Agent Gateway proxy has reported unsynchronized configuration for 5 minutes.
             runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/dsx-agent-gateway/README.md
         - alert: AgentGatewayHighErrorRate
-          expr: |
-            sum by (gateway) (rate(agentgateway_requests_total{namespace="{{ .Release.Namespace }}",status=~"5.."}[5m]))
-              /
-            sum by (gateway) (rate(agentgateway_requests_total{namespace="{{ .Release.Namespace }}"}[5m]))
-              > 0.05
+          expr: sum by (gateway) (rate(agentgateway_requests_total{namespace="{{ .Release.Namespace }}",status=~"5.."}[5m])) / sum by (gateway) (rate(agentgateway_requests_total{namespace="{{ .Release.Namespace }}"}[5m])) > 0.05
           for: 10m
           labels:
             severity: warning
@@ -62,11 +56,7 @@ spec:
             description: The 5xx response rate has remained above 5 percent for 10 minutes.
             runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/dsx-agent-gateway/README.md
         - alert: AgentGatewayHighP99Latency
-          expr: |
-            histogram_quantile(
-              0.99,
-              sum by (le, gateway) (rate(agentgateway_request_duration_seconds_bucket{namespace="{{ .Release.Namespace }}"}[5m]))
-            ) > 5
+          expr: histogram_quantile(0.99, sum by (le, gateway) (rate(agentgateway_request_duration_seconds_bucket{namespace="{{ .Release.Namespace }}"}[5m]))) > 5
           for: 10m
           labels:
             severity: warning
@@ -76,10 +66,7 @@ spec:
             description: The p99 request latency has remained above 5 seconds for 10 minutes.
             runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/dsx-agent-gateway/README.md
         - alert: AgentGatewayXDSAuthorizationFailures
-          expr: |
-            sum by (namespace) (
-              increase(agentgateway_xds_auth_rq_failure_total{namespace="{{ .Release.Namespace }}"}[5m])
-            ) > 0
+          expr: sum by (namespace) (increase(agentgateway_xds_auth_rq_failure_total{namespace="{{ .Release.Namespace }}"}[5m])) > 0
           for: 5m
           labels:
             severity: warning

--- a/deploy/dsx-agent-gateway/templates/prometheus-rule.yaml
+++ b/deploy/dsx-agent-gateway/templates/prometheus-rule.yaml
@@ -78,9 +78,7 @@ spec:
         - alert: AgentGatewayXDSAuthorizationFailures
           expr: |
             sum by (namespace) (
-              increase(agentgateway_xds_auth_rq_total{namespace="{{ .Release.Namespace }}"}[5m])
-                -
-              increase(agentgateway_xds_auth_rq_success_total{namespace="{{ .Release.Namespace }}"}[5m])
+              increase(agentgateway_xds_auth_rq_failure_total{namespace="{{ .Release.Namespace }}"}[5m])
             ) > 0
           for: 5m
           labels:

--- a/deploy/dsx-agent-gateway/values.yaml
+++ b/deploy/dsx-agent-gateway/values.yaml
@@ -15,8 +15,6 @@ agentgateway:
     proxy:
       podMonitor:
         enabled: false
-    grafanaDashboard:
-      enabled: true
   # The parent chart owns metrics discovery through its ServiceMonitor.
   podAnnotations:
     prometheus.io/scrape: "false"

--- a/deploy/dsx-agent-gateway/values.yaml
+++ b/deploy/dsx-agent-gateway/values.yaml
@@ -185,6 +185,9 @@ bridge:
     tls: {}
 
 observability:
+  # PrometheusRule resources belong only in the common services cluster.
+  alerts:
+    enabled: false
   metrics:
     # false omits Prometheus Operator resources and disables chart-managed export.
     enabled: true

--- a/deploy/dsx-agent-gateway/values.yaml
+++ b/deploy/dsx-agent-gateway/values.yaml
@@ -15,6 +15,9 @@ agentgateway:
     proxy:
       podMonitor:
         enabled: false
+    grafanaDashboard:
+      enabled: false
+      labels: {}
   # The parent chart owns metrics discovery through its ServiceMonitor.
   podAnnotations:
     prometheus.io/scrape: "false"
@@ -186,6 +189,8 @@ observability:
   # PrometheusRule resources belong only in the common services cluster.
   alerts:
     enabled: false
+    team: ""
+    runbookUrl: ""
   metrics:
     # false omits Prometheus Operator resources and disables chart-managed export.
     enabled: true

--- a/deploy/dsx-agent-gateway/values.yaml
+++ b/deploy/dsx-agent-gateway/values.yaml
@@ -186,7 +186,6 @@ bridge:
     tls: {}
 
 observability:
-  # PrometheusRule resources belong only in the common services cluster.
   alerts:
     enabled: false
     team: ""

--- a/deploy/dsx-agent-gateway/values.yaml
+++ b/deploy/dsx-agent-gateway/values.yaml
@@ -7,6 +7,16 @@ runtimeClassName: ""
 agentgateway:
   enabled: true
   nameOverride: controller # Avoid collision with the release-named dataplane Service
+  # Reuse the upstream dashboard; the parent chart owns metrics discovery.
+  monitoring:
+    enabled: true
+    serviceMonitor:
+      enabled: false
+    proxy:
+      podMonitor:
+        enabled: false
+    grafanaDashboard:
+      enabled: true
   # The parent chart owns metrics discovery through its ServiceMonitor.
   podAnnotations:
     prometheus.io/scrape: "false"

--- a/deploy/dsx-agent-gateway/values.yaml
+++ b/deploy/dsx-agent-gateway/values.yaml
@@ -190,7 +190,6 @@ observability:
   alerts:
     enabled: false
     team: ""
-    runbookUrl: ""
   metrics:
     # false omits Prometheus Operator resources and disables chart-managed export.
     enabled: true

--- a/deploy/nats-event-bus/dashboards/nats-surveyor-dashboard.json
+++ b/deploy/nats-event-bus/dashboards/nats-surveyor-dashboard.json
@@ -1,0 +1,4962 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "iteration": 1644365183491,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "description": "Combined messages received by all servers",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 0
+      },
+      "id": 79,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.3.4",
+      "targets": [
+        {
+          "expr": "sum(rate(nats_core_recv_msgs_count{server_cluster=~\"$cluster\"}[1m]))",
+          "legendFormat": "Received",
+          "refId": "A"
+        }
+      ],
+      "title": "Received Messages",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "Combined messages sent by all servers",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 3,
+        "y": 0
+      },
+      "id": 80,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.3.4",
+      "targets": [
+        {
+          "expr": "sum(rate(nats_core_sent_msgs_count{server_cluster=~\"$cluster\"}[1m]))",
+          "legendFormat": "Sent",
+          "refId": "A"
+        }
+      ],
+      "title": "Sent Messages",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "Combined bytes received by all servers",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 0
+      },
+      "id": 53,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.3.4",
+      "targets": [
+        {
+          "expr": "sum(rate(nats_core_recv_bytes{server_cluster=~\"$cluster\"}[1m]))",
+          "legendFormat": "Received",
+          "refId": "A"
+        }
+      ],
+      "title": "Received Bytes",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "Combined bytes sent by all servers",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 9,
+        "y": 0
+      },
+      "id": 52,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.3.4",
+      "targets": [
+        {
+          "expr": "sum(rate(nats_core_sent_bytes{server_cluster=~\"$cluster\"}[1m]))",
+          "legendFormat": "Sent",
+          "refId": "A"
+        }
+      ],
+      "title": "Sent Bytes",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "Total current connections across all servers",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 12,
+        "y": 0
+      },
+      "id": 45,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.3.4",
+      "targets": [
+        {
+          "expr": "sum(nats_core_connection_count{server_cluster=~\"$cluster\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Connections",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "Slow consumers seen per second",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 14,
+        "y": 0
+      },
+      "id": 56,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.3.4",
+      "targets": [
+        {
+          "expr": "sum(rate(nats_core_slow_consumer_count{server_cluster=~\"$cluster\"}[1m]))",
+          "legendFormat": "Slow",
+          "refId": "A"
+        }
+      ],
+      "title": "Slow Consumers",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "Number of known clusters",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 16,
+        "y": 0
+      },
+      "id": 55,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.3.4",
+      "targets": [
+        {
+          "expr": "count(sum(nats_core_info{server_cluster=~\"$cluster\"}) by (server_cluster))",
+          "legendFormat": "Servers",
+          "refId": "A"
+        }
+      ],
+      "title": "Clusters",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "Number of known servers",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 18,
+        "y": 0
+      },
+      "id": 78,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.3.4",
+      "targets": [
+        {
+          "expr": "count(nats_core_info{server_cluster=~\"$cluster\"})",
+          "legendFormat": "Servers",
+          "refId": "A"
+        }
+      ],
+      "title": "Servers",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "Number of routes reported as active",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 20,
+        "y": 0
+      },
+      "id": 49,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.3.4",
+      "targets": [
+        {
+          "expr": "sum(nats_core_route_count{server_cluster=~\"$cluster\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Route Connections",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "Number of routes reported as active",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "0"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 22,
+        "y": 0
+      },
+      "id": 50,
+      "interval": "",
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.3.4",
+      "targets": [
+        {
+          "expr": "sum(nats_core_gateway_count{server_cluster=~\"$cluster\"})",
+          "legendFormat": "Gateways",
+          "refId": "A"
+        }
+      ],
+      "title": "Gateway Connections",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 248,
+      "panels": [],
+      "title": "JetStream Status",
+      "type": "row"
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 0,
+        "y": 5
+      },
+      "hideTimeOverride": true,
+      "id": 258,
+      "interval": "",
+      "links": [],
+      "maxPerRow": 12,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.3.4",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "exemplar": false,
+          "expr": "sum(nats_core_jetstream_filestore_size_bytes{})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Capacity",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(nats_core_jetstream_filestore_used_bytes{})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Consumed",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(nats_core_jetstream_filestore_reserved_bytes{})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Reserved",
+          "refId": "C"
+        }
+      ],
+      "title": "JS Filestore",
+      "transparent": true,
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 5,
+        "y": 5
+      },
+      "hideTimeOverride": true,
+      "id": 268,
+      "interval": "",
+      "links": [],
+      "maxPerRow": 12,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.3.4",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "exemplar": false,
+          "expr": "sum(nats_core_jetstream_memstore_size_bytes{})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Capacity",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(nats_core_jetstream_memstore_used_bytes{})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Consumed",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(nats_core_jetstream_memstore_reserved_bytes{})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Reserved",
+          "refId": "C"
+        }
+      ],
+      "title": "JS Memstore",
+      "transparent": true,
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.+_bytes.+/"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "Bps"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 10,
+        "y": 5
+      },
+      "hideTimeOverride": true,
+      "id": 207,
+      "interval": "",
+      "links": [],
+      "maxPerRow": 12,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "name"
+      },
+      "pluginVersion": "8.3.4",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "exemplar": false,
+          "expr": "group by(server_domain) (nats_core_jetstream_info{server_jetstream=\"true\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{server_domain}}",
+          "refId": "A"
+        }
+      ],
+      "title": "JS  Domains",
+      "transparent": true,
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.+_bytes.+/"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "Bps"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 12,
+        "y": 5
+      },
+      "hideTimeOverride": true,
+      "id": 217,
+      "interval": "",
+      "links": [],
+      "maxPerRow": 12,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "name"
+      },
+      "pluginVersion": "8.3.4",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "exemplar": false,
+          "expr": "(nats_core_jetstream_cluster_raft_group_leader * on(server_id) group_left(server_cluster,server_name, server_domain) nats_core_jetstream_info) > 0",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{server_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "JS  Meta-Leader",
+      "transparent": true,
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.+_bytes.+/"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "Bps"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 14,
+        "y": 5
+      },
+      "hideTimeOverride": true,
+      "id": 197,
+      "interval": "",
+      "links": [],
+      "maxPerRow": 12,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.3.4",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "exemplar": false,
+          "expr": "count(group by(server_cluster) (nats_core_jetstream_info{server_jetstream=\"true\"}))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "JS  Clusters",
+      "transparent": true,
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.+_bytes.+/"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "Bps"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 16,
+        "y": 5
+      },
+      "hideTimeOverride": true,
+      "id": 177,
+      "interval": "",
+      "links": [],
+      "maxPerRow": 12,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.3.4",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "exemplar": false,
+          "expr": "count(nats_core_jetstream_info{server_jetstream=\"true\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Enabled",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "count(nats_core_jetstream_enabled == 1)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Running",
+          "refId": "B"
+        }
+      ],
+      "title": "JS Servers",
+      "transparent": true,
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.+_bytes.+/"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "Bps"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 18,
+        "y": 5
+      },
+      "hideTimeOverride": true,
+      "id": 278,
+      "interval": "",
+      "links": [],
+      "maxPerRow": 12,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.3.4",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "exemplar": false,
+          "expr": "sum(nats_core_jetstream_ha_assets{})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Enabled",
+          "refId": "A"
+        }
+      ],
+      "title": "JS HA Assets",
+      "transparent": true,
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.+_bytes.+/"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "Bps"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 20,
+        "y": 5
+      },
+      "hideTimeOverride": true,
+      "id": 237,
+      "interval": "",
+      "links": [],
+      "maxPerRow": 12,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "8.3.4",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "exemplar": false,
+          "expr": "nats_core_jetstream_cluster_raft_group_replicas * on(server_id) group_left(server_domain, server_cluster,server_name) nats_core_jetstream_info > 0",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{server_domain}}:{{server_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Meta's Replicas",
+      "transparent": true,
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.+_bytes.+/"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "Bps"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 22,
+        "y": 5
+      },
+      "hideTimeOverride": true,
+      "id": 227,
+      "interval": "",
+      "links": [],
+      "maxPerRow": 12,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "8.3.4",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "exemplar": false,
+          "expr": "sum by (server_domain, leader) (nats_core_jetstream_cluster_raft_group_info{raft_group=\"_meta_\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{leader}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Meta's Votes",
+      "transparent": true,
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 43,
+      "panels": [],
+      "title": "Cluster Overview",
+      "type": "row"
+    },
+    {
+      "description": "Combined current connections",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Connections",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Subscriptions"
+            },
+            "properties": [
+              {
+                "id": "custom.axisLabel",
+                "value": "Subscriptions"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 33,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max",
+            "min"
+          ],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.3.4",
+      "targets": [
+        {
+          "expr": "sum(nats_core_connection_count{server_cluster=~\"$cluster\"})",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Connections",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(nats_core_subs_count{server_cluster=~\"$cluster\"})",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Subscriptions",
+          "refId": "B"
+        }
+      ],
+      "title": "Cluster Connections",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "Combined slow consumers detected per second",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "min"
+          ],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.3.4",
+      "targets": [
+        {
+          "expr": "sum(rate(nats_core_slow_consumer_count{server_cluster=~\"$cluster\"}[1m]))",
+          "legendFormat": "Slow Consumers",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Slow Consumers",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "JetStream API requests per second by server (stacked)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "requests / second",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 309,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "min"
+          ],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.3.4",
+      "targets": [
+        {
+          "expr": "rate(nats_core_jetstream_api_requests{server_cluster=~\"$cluster\"}[$__rate_interval])",
+          "legendFormat": "{{server_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster JetStream API Requests",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "JetStream API requests pending processing (stacked)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "pending requests",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 310,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "min"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.3.4",
+      "targets": [
+        {
+          "expr": "nats_core_jetstream_api_pending{server_cluster=~\"$cluster\"}",
+          "legendFormat": "{{server_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster JetStream API Pending",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "Combined total messages for all servers",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "messages / second",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max",
+            "min"
+          ],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.3.4",
+      "targets": [
+        {
+          "expr": "sum(rate(nats_core_sent_msgs_count{server_cluster=~\"$cluster\"}[1m]))",
+          "legendFormat": "Sent",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(nats_core_recv_msgs_count{server_cluster=~\"$cluster\"}[1m]))",
+          "legendFormat": "Received",
+          "refId": "B"
+        }
+      ],
+      "title": "Cluster Message Traffic",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "Combined cluster network usage",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "id": 29,
+      "interval": "",
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max",
+            "min"
+          ],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.3.4",
+      "targets": [
+        {
+          "expr": "sum(rate(nats_core_sent_bytes{server_cluster=~\"$cluster\"}[1m]))",
+          "legendFormat": "Sent",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(nats_core_recv_bytes{server_cluster=~\"$cluster\"}[1m]))",
+          "legendFormat": "Received",
+          "refId": "B"
+        }
+      ],
+      "title": "Cluster Network Usage",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "description": "Distribution of NATS Server Versions across the cluster",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 8,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.3.4",
+      "targets": [
+        {
+          "expr": "sum(nats_core_info{server_cluster=~\"$cluster\"}) by (server_version)",
+          "legendFormat": "{{server_version}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Server Versions",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "cards": {},
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "linear",
+        "colorScheme": "interpolateYlOrRd",
+        "exponent": 0.5,
+        "mode": "opacity"
+      },
+      "dataFormat": "timeseries",
+      "description": "RTT times for the cluster as observed from the Surveyor",
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "heatmap": {},
+      "hideZeroBuckets": false,
+      "highlightCards": true,
+      "id": 92,
+      "interval": "",
+      "legend": {
+        "show": false
+      },
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "expr": "nats_core_rtt_nanoseconds",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "RTT",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster RTT",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "yAxis": {
+        "format": "ns",
+        "logBase": 1,
+        "show": true
+      },
+      "yBucketBound": "auto",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prom_ds}"
+      }
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 18,
+      "panels": [
+        {
+          "description": "Point in time view of clients connected to each Server",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "current connections",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 6
+          },
+          "id": 14,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "nats_core_connection_count{server_cluster=~\"$cluster\"}",
+              "legendFormat": "{{server_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current Connections",
+          "type": "timeseries"
+        },
+        {
+          "description": "Number of subscriptions active on the server",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "subscriptions",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 6
+          },
+          "id": 20,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "nats_core_subs_count{server_cluster=~\"$cluster\"}",
+              "legendFormat": "{{server_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Active Subscriptions",
+          "type": "timeseries"
+        },
+        {
+          "description": "Connections received by the server in a second",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "connections / sec",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 13
+          },
+          "id": 16,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "rate(nats_core_total_connection_count{server_cluster=~\"$cluster\"}[1m])",
+              "legendFormat": "{{server_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Connections per second",
+          "type": "timeseries"
+        },
+        {
+          "description": "The difference in subscription count per minute",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "subscriptions",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "id": 22,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "delta(nats_core_subs_count{server_cluster=~\"$cluster\"}[1m])",
+              "legendFormat": "{{server_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Subscription Delta",
+          "type": "timeseries"
+        },
+        {
+          "description": "Slow consumers detected by each server",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "slow / second",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 20
+          },
+          "id": 41,
+          "interval": "",
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "rate(nats_core_slow_consumer_count{server_cluster=~\"$cluster\"}[1m])",
+              "legendFormat": "{{server_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Slow Consumers",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Client Connection Detail",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 71,
+      "panels": [
+        {
+          "description": "Bytes sent for each gateway",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "bytes / sec",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 7
+          },
+          "id": 72,
+          "interval": "",
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "rate(nats_core_gateway_sent_bytes{server_cluster=~\"$cluster\"}[1m])",
+              "legendFormat": "{{server_name}} - {{server_cluster}} -> {{server_gateway_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Gateway Bytes Sent",
+          "type": "timeseries"
+        },
+        {
+          "description": "Bytes received for each gateway",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "bytes / sec",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 7
+          },
+          "id": 73,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "rate(nats_core_gateway_recv_bytes{server_cluster=~\"$cluster\"}[1m])",
+              "legendFormat": "{{server_name}} - {{server_cluster}} -> {{server_gateway_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Gateway Bytes Received",
+          "type": "timeseries"
+        },
+        {
+          "description": "Messages sent for each gateway",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "messages / sec",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 14
+          },
+          "id": 74,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "rate(nats_core_gateway_sent_msgs_count{server_cluster=~\"$cluster\"}[1m])",
+              "legendFormat": "{{server_name}} - {{server_cluster}} -> {{server_gateway_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Gateway Messages Sent",
+          "type": "timeseries"
+        },
+        {
+          "description": "Messages received for each gateway",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "messages / sec",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 14
+          },
+          "id": 75,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "rate(nats_core_gateway_recv_msg_count{server_cluster=~\"$cluster\"}[1m])",
+              "legendFormat": "{{server_name}} - {{server_cluster}} -> {{server_gateway_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Gateway Messages Received",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Gateway Details",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 60,
+      "panels": [
+        {
+          "description": "Bytes sent for each route",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "bytes / sec",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "id": 62,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "rate(nats_core_route_sent_bytes{server_cluster=~\"$cluster\"}[1m])",
+              "legendFormat": "Server {{server_name}} - Route {{server_route_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Route Bytes Sent",
+          "type": "timeseries"
+        },
+        {
+          "description": "Bytes received for each route",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "bytes / sec",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "id": 63,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "rate(nats_core_route_recv_bytes{server_cluster=~\"$cluster\"}[1m])",
+              "legendFormat": "Server {{server_name}} - Route {{server_route_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Route Bytes Received",
+          "type": "timeseries"
+        },
+        {
+          "description": "Messages sent for each route",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "messages / sec",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 15
+          },
+          "id": 64,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "rate(nats_core_route_sent_msg_count{server_cluster=~\"$cluster\"}[1m])",
+              "legendFormat": "Server {{server_name}} - Route {{server_route_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Route Messages Sent",
+          "type": "timeseries"
+        },
+        {
+          "description": "Messages received for each route",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "messages / sec",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 15
+          },
+          "id": 65,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "rate(nats_core_route_recv_msg_count{server_cluster=~\"$cluster\"}[1m])",
+              "legendFormat": "Server {{server_name}} - Route {{server_route_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Route Messages Received",
+          "type": "timeseries"
+        },
+        {
+          "description": "The number of servers in each cluster",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "cluster size",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 22
+          },
+          "id": 10,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "sum(nats_core_info{server_cluster=~\"$cluster\"}) by (server_cluster)",
+              "legendFormat": "{{server_cluster}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Cluster Size",
+          "type": "timeseries"
+        },
+        {
+          "description": "Data in the pending buffers that needs to be sent to remotes",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 22
+          },
+          "id": 67,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "nats_core_route_pending_bytes{server_cluster=~\"$cluster\"}",
+              "legendFormat": "Server {{server_name}} - Route {{server_route_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Route Pending Data",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Route Details",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "id": 24,
+      "panels": [
+        {
+          "description": "Data sent per second",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "id": 26,
+          "interval": "",
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "rate(nats_core_sent_bytes{server_cluster=~\"$cluster\"}[1m])",
+              "legendFormat": "{{server_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes Sent",
+          "type": "timeseries"
+        },
+        {
+          "description": "Data received per second",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "id": 27,
+          "interval": "",
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "rate(nats_core_recv_bytes{server_cluster=~\"$cluster\"}[1m])",
+              "legendFormat": "{{server_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes Received",
+          "type": "timeseries"
+        },
+        {
+          "description": "Messages sent per second",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "id": 68,
+          "interval": "",
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "rate(nats_core_sent_msgs_count{server_cluster=~\"$cluster\"}[1m])",
+              "legendFormat": "{{server_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Messages Sent",
+          "type": "timeseries"
+        },
+        {
+          "description": "Messages received per second",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "id": 69,
+          "interval": "",
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "rate(nats_core_recv_msgs_count{server_cluster=~\"$cluster\"}[1m])",
+              "legendFormat": "{{server_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Messages Received",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Network Usage Detail",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 77,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prom_ds}"
+          },
+          "description": "CPU used by the NATS Server process. 100% = 1 core fully utilized.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "cpu %",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "id": 4,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "nats_core_cpu_percentage{server_cluster=~\"$cluster\"}",
+              "legendFormat": "{{server_name}}",
+              "refId": "B"
+            }
+          ],
+          "title": "CPU Usage (100% = 1 core)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prom_ds}"
+          },
+          "description": "RSS memory in use by the NATS server process",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "Bytes",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": ".*GOMEMLIMIT.*"
+                },
+                "properties": [
+                  {
+                    "id": "custom.lineStyle",
+                    "value": {
+                      "dash": [
+                        10,
+                        10
+                      ],
+                      "fill": "dash"
+                    }
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 10
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "nats_core_mem_bytes{server_cluster=~\"$cluster\"}",
+              "legendFormat": "{{server_name}} (usage)",
+              "refId": "A"
+            },
+            {
+              "expr": "nats_core_go_memlimit_bytes{server_cluster=~\"$cluster\"}",
+              "legendFormat": "{{server_name}} (GOMEMLIMIT)",
+              "refId": "B"
+            }
+          ],
+          "title": "Memory (RSS)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prom_ds}"
+          },
+          "description": "CPU used by the NATS Server process normalized by number of cores (% of total machine capacity)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "% of total CPU",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "id": 100,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "nats_core_cpu_percentage{server_cluster=~\"$cluster\"} / nats_core_core_count{server_cluster=~\"$cluster\"}",
+              "legendFormat": "{{server_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "CPU Usage (Normalized)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prom_ds}"
+          },
+          "id": 85,
+          "type": "timeseries",
+          "title": "Memory Usage (% of GOMEMLIMIT)",
+          "gridPos": {
+            "x": 12,
+            "y": 17,
+            "h": 7,
+            "w": 12
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "lineWidth": 2,
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "spanNulls": true,
+                "insertNulls": false,
+                "showPoints": "never",
+                "pointSize": 5,
+                "stacking": {
+                  "mode": "none",
+                  "group": "A"
+                },
+                "axisPlacement": "auto",
+                "axisLabel": "",
+                "axisColorMode": "text",
+                "axisBorderShow": false,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "axisCenteredZero": false,
+                "hideFrom": {
+                  "tooltip": false,
+                  "viz": false,
+                  "legend": false
+                },
+                "thresholdsStyle": {
+                  "mode": "line"
+                }
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "value": 0,
+                    "color": "#EAB839"
+                  }
+                ]
+              },
+              "links": [],
+              "max": 100,
+              "min": 0,
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "nats_core_mem_bytes{server_cluster=~\"$cluster\"} / nats_core_go_memlimit_bytes{server_cluster=~\"$cluster\"} * 100",
+              "legendFormat": "{{server_name}}",
+              "refId": "A",
+              "editorMode": "code",
+              "range": true
+            }
+          ],
+          "options": {
+            "tooltip": {
+              "mode": "single",
+              "sort": "none",
+              "hideZeros": false
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "min"
+              ]
+            }
+          }
+        }
+      ],
+      "title": "Node Resource Usage",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 84,
+      "panels": [
+        {
+          "description": "The number of NATS Servers expected to reply vs how many replied during a poll",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "Expected",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 11
+          },
+          "id": 82,
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "nats_survey_expected_count",
+              "legendFormat": "Expected",
+              "refId": "A"
+            },
+            {
+              "expr": "nats_survey_surveyed_count",
+              "legendFormat": "Responded",
+              "refId": "B"
+            }
+          ],
+          "title": "Expected vs Received",
+          "type": "timeseries"
+        },
+        {
+          "description": "Cluster wide RTT as calculated from the Surveyor",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "RTT",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ns"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 24,
+            "x": 0,
+            "y": 18
+          },
+          "id": 39,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "rate(nats_core_rtt_nanoseconds[1m])",
+              "legendFormat": "{{server_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Cluster RTT",
+          "type": "timeseries"
+        },
+        {
+          "description": "Number of times the surveyor reconnected to the network in a minute",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 23
+          },
+          "id": 90,
+          "interval": "",
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": "increase(nats_survey_nats_reconnects[5m])",
+              "legendFormat": "Reconnections",
+              "refId": "A"
+            }
+          ],
+          "title": "NATS Reconnects",
+          "type": "timeseries"
+        },
+        {
+          "description": "Time it takes the surveyor to gather the statistics from surveyed NATS Servers",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "time per poll",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 23
+          },
+          "id": 86,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.4",
+          "targets": [
+            {
+              "expr": " rate(nats_survey_duration_seconds_sum[5m])\n/\n  rate(nats_survey_duration_seconds_count[5m])",
+              "legendFormat": "Poll Time",
+              "refId": "A"
+            }
+          ],
+          "title": "Poll Time",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Surveyor",
+      "type": "row"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 34,
+  "style": "dark",
+  "tags": [
+    "surveyor"
+  ],
+  "templating": {
+    "list": [
+      {
+        "type": "datasource",
+        "name": "prom_ds",
+        "label": "Prometheus Datasource",
+        "query": "prometheus",
+        "refresh": 1
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prom_ds}"
+        },
+        "definition": "label_values(nats_core_info, server_cluster)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(nats_core_info, server_cluster)",
+          "refId": "Prometheus-cluster-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prom_ds}"
+        },
+        "definition": "query_result(nats_survey_expected_count)",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "expected",
+        "options": [],
+        "query": {
+          "query": "query_result(nats_survey_expected_count)",
+          "refId": "Prometheus-expected-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "/.* ([^\\ ]*) .*/",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "NATS Surveyor",
+  "uid": "GGxJ_5oZy",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/nats-event-bus/templates/grafana-dashboard.yaml
+++ b/deploy/nats-event-bus/templates/grafana-dashboard.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nats-surveyor-dashboard
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: nats-surveyor
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: grafana-dashboard
+    grafana_dashboard: "1"
+  annotations:
+    grafana.com/dashboard-folder: "DSX Event Bus"
+data:
+  # Vendored from NATS Surveyor v0.9.7 to match the chart's Surveyor image.
+  nats-surveyor.json: |
+{{ required "dashboards/nats-surveyor-dashboard.json is required" (.Files.Get "dashboards/nats-surveyor-dashboard.json") | indent 4 }}

--- a/deploy/nats-event-bus/templates/grafana-dashboard.yaml
+++ b/deploy/nats-event-bus/templates/grafana-dashboard.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nats-surveyor-dashboard
+  name: {{ .Release.Name }}-surveyor-dashboard
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: nats-surveyor

--- a/deploy/nats-event-bus/templates/grafana-dashboard.yaml
+++ b/deploy/nats-event-bus/templates/grafana-dashboard.yaml
@@ -1,7 +1,7 @@
 # Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.surveyor.grafanaDashboard.enabled }}
+{{- if .Values.global.eventBus.grafanaDashboard.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,10 +12,10 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: grafana-dashboard
-    {{- with .Values.surveyor.grafanaDashboard.labels }}
+    {{- with .Values.global.eventBus.grafanaDashboard.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.surveyor.grafanaDashboard.annotations }}
+  {{- with .Values.global.eventBus.grafanaDashboard.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/deploy/nats-event-bus/templates/grafana-dashboard.yaml
+++ b/deploy/nats-event-bus/templates/grafana-dashboard.yaml
@@ -1,6 +1,7 @@
 # Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+{{- if .Values.surveyor.grafanaDashboard.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,10 +12,15 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: grafana-dashboard
-    grafana_dashboard: "1"
+    {{- with .Values.surveyor.grafanaDashboard.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.surveyor.grafanaDashboard.annotations }}
   annotations:
-    grafana.com/dashboard-folder: "DSX Event Bus"
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   # Vendored from NATS Surveyor v0.9.7 to match the chart's Surveyor image.
   nats-surveyor.json: |
 {{ required "dashboards/nats-surveyor-dashboard.json is required" (.Files.Get "dashboards/nats-surveyor-dashboard.json") | indent 4 }}
+{{- end }}

--- a/deploy/nats-event-bus/templates/prometheus-rule.yaml
+++ b/deploy/nats-event-bus/templates/prometheus-rule.yaml
@@ -1,0 +1,78 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.global.eventBus.alerts.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Release.Name }}-alerts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: nats-event-bus
+    app.kubernetes.io/component: alerting
+spec:
+  groups:
+    - name: nats-event-bus.rules
+      interval: 30s
+      rules:
+        - alert: NATSSurveyorMetricsAbsent
+          expr: absent(nats_survey_expected_count{namespace="{{ .Release.Namespace }}"}) == 1
+          for: 10m
+          labels:
+            severity: critical
+            team: dsx
+          annotations:
+            summary: NATS Surveyor metrics are unavailable.
+            description: No NATS Surveyor metrics have been observed for 10 minutes.
+            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/README.md
+        - alert: NATSSurveyIncomplete
+          expr: nats_survey_surveyed_count{namespace="{{ .Release.Namespace }}"} < nats_survey_expected_count{namespace="{{ .Release.Namespace }}"}
+          for: 5m
+          labels:
+            severity: critical
+            team: dsx
+          annotations:
+            summary: NATS Surveyor cannot reach every expected server.
+            description: The number of surveyed NATS servers is below the expected count.
+            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/README.md
+        - alert: NATSRepeatedReconnects
+          expr: increase(nats_survey_nats_reconnects{namespace="{{ .Release.Namespace }}"}[10m]) > 2
+          for: 5m
+          labels:
+            severity: warning
+            team: dsx
+          annotations:
+            summary: NATS Surveyor is repeatedly reconnecting.
+            description: Surveyor reconnected to NATS more than twice in 10 minutes.
+            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/README.md
+        - alert: NATSSlowConsumers
+          expr: sum by (server_cluster) (increase(nats_core_slow_consumer_count{namespace="{{ .Release.Namespace }}"}[5m])) > 0
+          for: 5m
+          labels:
+            severity: warning
+            team: dsx
+          annotations:
+            summary: NATS detected slow consumers.
+            description: A NATS cluster has continued to detect slow consumers.
+            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/README.md
+        - alert: NATSHighMemoryUsage
+          expr: nats_core_mem_bytes{namespace="{{ .Release.Namespace }}"} / nats_core_go_memlimit_bytes{namespace="{{ .Release.Namespace }}"} > 0.8
+          for: 15m
+          labels:
+            severity: warning
+            team: dsx
+          annotations:
+            summary: A NATS server is using more than 80 percent of its memory limit.
+            description: NATS memory usage has remained above 80 percent for 15 minutes.
+            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/README.md
+        - alert: NATSRoutePendingData
+          expr: sum by (server_cluster, server_name) (nats_core_route_pending_bytes{namespace="{{ .Release.Namespace }}"}) > 1048576
+          for: 10m
+          labels:
+            severity: warning
+            team: dsx
+          annotations:
+            summary: A NATS route has more than 1 MiB of pending data.
+            description: Pending route data has remained above 1 MiB for 10 minutes.
+            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/README.md
+{{- end }}

--- a/deploy/nats-event-bus/templates/prometheus-rule.yaml
+++ b/deploy/nats-event-bus/templates/prometheus-rule.yaml
@@ -1,7 +1,7 @@
 # Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.global.eventBus.alerts.enabled }}
+{{- if and (eq .Values.global.eventBus.clusterType "csc") .Values.global.eventBus.alerts.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/deploy/nats-event-bus/templates/prometheus-rule.yaml
+++ b/deploy/nats-event-bus/templates/prometheus-rule.yaml
@@ -1,7 +1,7 @@
 # Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if and (eq .Values.global.eventBus.clusterType "csc") .Values.global.eventBus.alerts.enabled }}
+{{- if .Values.global.eventBus.alerts.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/deploy/nats-event-bus/templates/prometheus-rule.yaml
+++ b/deploy/nats-event-bus/templates/prometheus-rule.yaml
@@ -24,7 +24,6 @@ spec:
           annotations:
             summary: NATS Surveyor metrics are unavailable.
             description: No NATS Surveyor metrics have been observed for 10 minutes.
-            runbook_url: {{ .Values.global.eventBus.alerts.runbookUrl | quote }}
         - alert: NATSSurveyIncomplete
           expr: nats_survey_surveyed_count{namespace="{{ .Release.Namespace }}"} < nats_survey_expected_count{namespace="{{ .Release.Namespace }}"}
           for: 5m
@@ -34,7 +33,6 @@ spec:
           annotations:
             summary: NATS Surveyor cannot reach every expected server.
             description: The number of surveyed NATS servers is below the expected count.
-            runbook_url: {{ .Values.global.eventBus.alerts.runbookUrl | quote }}
         - alert: NATSRepeatedReconnects
           expr: increase(nats_survey_nats_reconnects{namespace="{{ .Release.Namespace }}"}[10m]) > 2
           for: 5m
@@ -44,7 +42,6 @@ spec:
           annotations:
             summary: NATS Surveyor is repeatedly reconnecting.
             description: Surveyor reconnected to NATS more than twice in 10 minutes.
-            runbook_url: {{ .Values.global.eventBus.alerts.runbookUrl | quote }}
         - alert: NATSSlowConsumers
           expr: sum by (server_cluster) (nats_core_slow_consumer_count{namespace="{{ .Release.Namespace }}"}) > 0
           for: 5m
@@ -54,7 +51,6 @@ spec:
           annotations:
             summary: NATS detected slow consumers.
             description: A NATS cluster has continued to detect slow consumers.
-            runbook_url: {{ .Values.global.eventBus.alerts.runbookUrl | quote }}
         - alert: NATSHighMemoryUsage
           expr: (nats_core_mem_bytes{namespace="{{ .Release.Namespace }}"} / nats_core_go_memlimit_bytes{namespace="{{ .Release.Namespace }}"} > 0.8) and nats_core_go_memlimit_bytes{namespace="{{ .Release.Namespace }}"} > 0
           for: 15m
@@ -64,7 +60,6 @@ spec:
           annotations:
             summary: A NATS server is using more than 80 percent of its memory limit.
             description: NATS memory usage has remained above 80 percent for 15 minutes.
-            runbook_url: {{ .Values.global.eventBus.alerts.runbookUrl | quote }}
         - alert: NATSRoutePendingData
           expr: sum by (server_cluster, server_name, server_id, server_route_name, server_route_name_id) (nats_core_route_pending_bytes{namespace="{{ .Release.Namespace }}"}) > 1048576
           for: 10m
@@ -74,5 +69,4 @@ spec:
           annotations:
             summary: A NATS route has more than 1 MiB of pending data.
             description: Pending route data has remained above 1 MiB for 10 minutes.
-            runbook_url: {{ .Values.global.eventBus.alerts.runbookUrl | quote }}
 {{- end }}

--- a/deploy/nats-event-bus/templates/prometheus-rule.yaml
+++ b/deploy/nats-event-bus/templates/prometheus-rule.yaml
@@ -46,7 +46,7 @@ spec:
             description: Surveyor reconnected to NATS more than twice in 10 minutes.
             runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/README.md
         - alert: NATSSlowConsumers
-          expr: sum by (server_cluster) (increase(nats_core_slow_consumer_count{namespace="{{ .Release.Namespace }}"}[5m])) > 0
+          expr: sum by (server_cluster) (nats_core_slow_consumer_count{namespace="{{ .Release.Namespace }}"}) > 0
           for: 5m
           labels:
             severity: warning
@@ -56,7 +56,7 @@ spec:
             description: A NATS cluster has continued to detect slow consumers.
             runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/README.md
         - alert: NATSHighMemoryUsage
-          expr: nats_core_mem_bytes{namespace="{{ .Release.Namespace }}"} / nats_core_go_memlimit_bytes{namespace="{{ .Release.Namespace }}"} > 0.8
+          expr: (nats_core_mem_bytes{namespace="{{ .Release.Namespace }}"} / nats_core_go_memlimit_bytes{namespace="{{ .Release.Namespace }}"} > 0.8) and nats_core_go_memlimit_bytes{namespace="{{ .Release.Namespace }}"} > 0
           for: 15m
           labels:
             severity: warning
@@ -66,7 +66,7 @@ spec:
             description: NATS memory usage has remained above 80 percent for 15 minutes.
             runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/README.md
         - alert: NATSRoutePendingData
-          expr: sum by (server_cluster, server_name) (nats_core_route_pending_bytes{namespace="{{ .Release.Namespace }}"}) > 1048576
+          expr: sum by (server_cluster, server_name, server_id, server_route_name, server_route_name_id) (nats_core_route_pending_bytes{namespace="{{ .Release.Namespace }}"}) > 1048576
           for: 10m
           labels:
             severity: warning

--- a/deploy/nats-event-bus/templates/prometheus-rule.yaml
+++ b/deploy/nats-event-bus/templates/prometheus-rule.yaml
@@ -20,59 +20,59 @@ spec:
           for: 10m
           labels:
             severity: critical
-            team: dsx
+            team: {{ .Values.global.eventBus.alerts.team | quote }}
           annotations:
             summary: NATS Surveyor metrics are unavailable.
             description: No NATS Surveyor metrics have been observed for 10 minutes.
-            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/README.md
+            runbook_url: {{ .Values.global.eventBus.alerts.runbookUrl | quote }}
         - alert: NATSSurveyIncomplete
           expr: nats_survey_surveyed_count{namespace="{{ .Release.Namespace }}"} < nats_survey_expected_count{namespace="{{ .Release.Namespace }}"}
           for: 5m
           labels:
             severity: critical
-            team: dsx
+            team: {{ .Values.global.eventBus.alerts.team | quote }}
           annotations:
             summary: NATS Surveyor cannot reach every expected server.
             description: The number of surveyed NATS servers is below the expected count.
-            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/README.md
+            runbook_url: {{ .Values.global.eventBus.alerts.runbookUrl | quote }}
         - alert: NATSRepeatedReconnects
           expr: increase(nats_survey_nats_reconnects{namespace="{{ .Release.Namespace }}"}[10m]) > 2
           for: 5m
           labels:
             severity: warning
-            team: dsx
+            team: {{ .Values.global.eventBus.alerts.team | quote }}
           annotations:
             summary: NATS Surveyor is repeatedly reconnecting.
             description: Surveyor reconnected to NATS more than twice in 10 minutes.
-            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/README.md
+            runbook_url: {{ .Values.global.eventBus.alerts.runbookUrl | quote }}
         - alert: NATSSlowConsumers
           expr: sum by (server_cluster) (nats_core_slow_consumer_count{namespace="{{ .Release.Namespace }}"}) > 0
           for: 5m
           labels:
             severity: warning
-            team: dsx
+            team: {{ .Values.global.eventBus.alerts.team | quote }}
           annotations:
             summary: NATS detected slow consumers.
             description: A NATS cluster has continued to detect slow consumers.
-            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/README.md
+            runbook_url: {{ .Values.global.eventBus.alerts.runbookUrl | quote }}
         - alert: NATSHighMemoryUsage
           expr: (nats_core_mem_bytes{namespace="{{ .Release.Namespace }}"} / nats_core_go_memlimit_bytes{namespace="{{ .Release.Namespace }}"} > 0.8) and nats_core_go_memlimit_bytes{namespace="{{ .Release.Namespace }}"} > 0
           for: 15m
           labels:
             severity: warning
-            team: dsx
+            team: {{ .Values.global.eventBus.alerts.team | quote }}
           annotations:
             summary: A NATS server is using more than 80 percent of its memory limit.
             description: NATS memory usage has remained above 80 percent for 15 minutes.
-            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/README.md
+            runbook_url: {{ .Values.global.eventBus.alerts.runbookUrl | quote }}
         - alert: NATSRoutePendingData
           expr: sum by (server_cluster, server_name, server_id, server_route_name, server_route_name_id) (nats_core_route_pending_bytes{namespace="{{ .Release.Namespace }}"}) > 1048576
           for: 10m
           labels:
             severity: warning
-            team: dsx
+            team: {{ .Values.global.eventBus.alerts.team | quote }}
           annotations:
             summary: A NATS route has more than 1 MiB of pending data.
             description: Pending route data has remained above 1 MiB for 10 minutes.
-            runbook_url: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/README.md
+            runbook_url: {{ .Values.global.eventBus.alerts.runbookUrl | quote }}
 {{- end }}

--- a/deploy/nats-event-bus/templates/prometheus-rule.yaml
+++ b/deploy/nats-event-bus/templates/prometheus-rule.yaml
@@ -16,7 +16,7 @@ spec:
       interval: 30s
       rules:
         - alert: NATSSurveyorMetricsAbsent
-          expr: absent(nats_survey_expected_count{namespace="{{ .Release.Namespace }}"}) == 1
+          expr: absent(nats_survey_expected_count{namespace="{{ .Release.Namespace }}"})
           for: 10m
           labels:
             severity: critical

--- a/deploy/nats-event-bus/values.yaml
+++ b/deploy/nats-event-bus/values.yaml
@@ -78,7 +78,6 @@ global:
     alerts:
       enabled: false
       team: ""
-      runbookUrl: ""
 
     # Extra NATS accounts.
     #

--- a/deploy/nats-event-bus/values.yaml
+++ b/deploy/nats-event-bus/values.yaml
@@ -74,7 +74,6 @@ global:
     mtls:
       enabled: true
 
-    # PrometheusRule resources belong only in the common services cluster.
     alerts:
       enabled: false
       team: ""

--- a/deploy/nats-event-bus/values.yaml
+++ b/deploy/nats-event-bus/values.yaml
@@ -74,6 +74,10 @@ global:
     mtls:
       enabled: true
 
+    # PrometheusRule resources belong only in the common services cluster.
+    alerts:
+      enabled: false
+
     # Extra NATS accounts.
     #
     # Extra accounts are rendered as native accounts on every cluster where they

--- a/deploy/nats-event-bus/values.yaml
+++ b/deploy/nats-event-bus/values.yaml
@@ -77,6 +77,8 @@ global:
     # PrometheusRule resources belong only in the common services cluster.
     alerts:
       enabled: false
+      team: ""
+      runbookUrl: ""
 
     # Extra NATS accounts.
     #
@@ -577,6 +579,10 @@ auth-callout:
 # Surveyor configuration - Prometheus metrics exporter for NATS monitoring
 # See https://github.com/nats-io/nats-surveyor for metrics reference
 surveyor:
+  grafanaDashboard:
+    enabled: false
+    labels: {}
+    annotations: {}
   resources:
     requests:
       cpu: 10m

--- a/deploy/nats-event-bus/values.yaml
+++ b/deploy/nats-event-bus/values.yaml
@@ -78,6 +78,11 @@ global:
       enabled: false
       team: ""
 
+    grafanaDashboard:
+      enabled: false
+      labels: {}
+      annotations: {}
+
     # Extra NATS accounts.
     #
     # Extra accounts are rendered as native accounts on every cluster where they
@@ -577,10 +582,6 @@ auth-callout:
 # Surveyor configuration - Prometheus metrics exporter for NATS monitoring
 # See https://github.com/nats-io/nats-surveyor for metrics reference
 surveyor:
-  grafanaDashboard:
-    enabled: false
-    labels: {}
-    annotations: {}
   resources:
     requests:
       cpu: 10m

--- a/local/agent-gateway/tests/functional/session_protocol_health_test.go
+++ b/local/agent-gateway/tests/functional/session_protocol_health_test.go
@@ -285,6 +285,18 @@ func TestPrometheusMonitorResourcesLive(t *testing.T) {
 				}
 				continue
 			}
+			if tc.gvr == podMonitor && tc.name == cscGatewayName {
+				relabelings, found, err := unstructured.NestedSlice(endpoint, "relabelings")
+				if err != nil || !found || len(relabelings) != 1 {
+					t.Fatalf("PodMonitor %s/%s relabelings invalid: found=%t count=%d err=%v", tc.ns, tc.name, found, len(relabelings), err)
+				}
+				relabeling, ok := relabelings[0].(map[string]any)
+				sourceLabels, sourceLabelsFound, sourceLabelsErr := unstructured.NestedStringSlice(relabeling, "sourceLabels")
+				if !ok || sourceLabelsErr != nil || !sourceLabelsFound || len(sourceLabels) != 1 || sourceLabels[0] != "__meta_kubernetes_pod_label_gateway_networking_k8s_io_gateway_name" ||
+					relabeling["targetLabel"] != "gateway_networking_k8s_io_gateway_name" {
+					t.Errorf("PodMonitor %s/%s dashboard relabeling = %v", tc.ns, tc.name, relabelings[0])
+				}
+			}
 			port, ok := endpoint["port"].(string)
 			if !ok || port == "" {
 				t.Errorf("%s %s/%s endpoint port = %v, want named port", tc.gvr.Resource, tc.ns, tc.name, endpoint["port"])
@@ -331,6 +343,39 @@ func TestPrometheusMonitorResourcesLive(t *testing.T) {
 		context.Background(), cpc1GatewayNS+"-bridge", metav1.GetOptions{},
 	); !apierrors.IsNotFound(err) {
 		t.Fatalf("leaf bridge ServiceMonitor lookup error = %v, want not found", err)
+	}
+}
+
+func TestGrafanaDashboardSourcesLive(t *testing.T) {
+	runner.ParallelReadOnly(t)
+
+	for _, tc := range []struct {
+		name       string
+		ns         string
+		key        string
+		title      string
+		panelCount int
+	}{
+		{name: "nats-surveyor-dashboard", ns: cscEventBusNS, key: "nats-surveyor.json", title: "NATS Surveyor", panelCount: 35},
+		{name: cscGatewayName + "-controller-dashboard", ns: cscGatewayNS, key: "agentgateway.json", title: "Agentgateway", panelCount: 13},
+	} {
+		configMap, err := runner.K8s(t).CoreV1().ConfigMaps(tc.ns).Get(context.Background(), tc.name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("get ConfigMap %s/%s: %v", tc.ns, tc.name, err)
+		}
+		if got := configMap.Labels["grafana_dashboard"]; got != "1" {
+			t.Errorf("ConfigMap %s/%s grafana_dashboard = %q, want 1", tc.ns, tc.name, got)
+		}
+		var dashboard struct {
+			Title  string            `json:"title"`
+			Panels []json.RawMessage `json:"panels"`
+		}
+		if err := json.Unmarshal([]byte(configMap.Data[tc.key]), &dashboard); err != nil {
+			t.Fatalf("parse ConfigMap %s/%s key %s: %v", tc.ns, tc.name, tc.key, err)
+		}
+		if dashboard.Title != tc.title || len(dashboard.Panels) != tc.panelCount {
+			t.Errorf("ConfigMap %s/%s dashboard = %q with %d panels, want %q with %d", tc.ns, tc.name, dashboard.Title, len(dashboard.Panels), tc.title, tc.panelCount)
+		}
 	}
 }
 

--- a/local/agent-gateway/tests/functional/session_protocol_health_test.go
+++ b/local/agent-gateway/tests/functional/session_protocol_health_test.go
@@ -285,18 +285,6 @@ func TestPrometheusMonitorResourcesLive(t *testing.T) {
 				}
 				continue
 			}
-			if tc.gvr == podMonitor && tc.name == cscGatewayName {
-				relabelings, found, err := unstructured.NestedSlice(endpoint, "relabelings")
-				if err != nil || !found || len(relabelings) != 1 {
-					t.Fatalf("PodMonitor %s/%s relabelings invalid: found=%t count=%d err=%v", tc.ns, tc.name, found, len(relabelings), err)
-				}
-				relabeling, ok := relabelings[0].(map[string]any)
-				sourceLabels, sourceLabelsFound, sourceLabelsErr := unstructured.NestedStringSlice(relabeling, "sourceLabels")
-				if !ok || sourceLabelsErr != nil || !sourceLabelsFound || len(sourceLabels) != 1 || sourceLabels[0] != "__meta_kubernetes_pod_label_gateway_networking_k8s_io_gateway_name" ||
-					relabeling["targetLabel"] != "gateway_networking_k8s_io_gateway_name" {
-					t.Errorf("PodMonitor %s/%s dashboard relabeling = %v", tc.ns, tc.name, relabelings[0])
-				}
-			}
 			port, ok := endpoint["port"].(string)
 			if !ok || port == "" {
 				t.Errorf("%s %s/%s endpoint port = %v, want named port", tc.gvr.Resource, tc.ns, tc.name, endpoint["port"])

--- a/local/agent-gateway/tests/functional/session_protocol_health_test.go
+++ b/local/agent-gateway/tests/functional/session_protocol_health_test.go
@@ -346,39 +346,6 @@ func TestPrometheusMonitorResourcesLive(t *testing.T) {
 	}
 }
 
-func TestGrafanaDashboardSourcesLive(t *testing.T) {
-	runner.ParallelReadOnly(t)
-
-	for _, tc := range []struct {
-		name       string
-		ns         string
-		key        string
-		title      string
-		panelCount int
-	}{
-		{name: "nats-surveyor-dashboard", ns: cscEventBusNS, key: "nats-surveyor.json", title: "NATS Surveyor", panelCount: 35},
-		{name: cscGatewayName + "-controller-dashboard", ns: cscGatewayNS, key: "agentgateway.json", title: "Agentgateway", panelCount: 13},
-	} {
-		configMap, err := runner.K8s(t).CoreV1().ConfigMaps(tc.ns).Get(context.Background(), tc.name, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("get ConfigMap %s/%s: %v", tc.ns, tc.name, err)
-		}
-		if got := configMap.Labels["grafana_dashboard"]; got != "1" {
-			t.Errorf("ConfigMap %s/%s grafana_dashboard = %q, want 1", tc.ns, tc.name, got)
-		}
-		var dashboard struct {
-			Title  string            `json:"title"`
-			Panels []json.RawMessage `json:"panels"`
-		}
-		if err := json.Unmarshal([]byte(configMap.Data[tc.key]), &dashboard); err != nil {
-			t.Fatalf("parse ConfigMap %s/%s key %s: %v", tc.ns, tc.name, tc.key, err)
-		}
-		if dashboard.Title != tc.title || len(dashboard.Panels) != tc.panelCount {
-			t.Errorf("ConfigMap %s/%s dashboard = %q with %d panels, want %q with %d", tc.ns, tc.name, dashboard.Title, len(dashboard.Panels), tc.title, tc.panelCount)
-		}
-	}
-}
-
 func TestOpenTelemetryOperatorInjectionContract(t *testing.T) {
 	runner.ParallelReadOnly(t)
 

--- a/local/agent-gateway/values/values.local.yaml
+++ b/local/agent-gateway/values/values.local.yaml
@@ -6,7 +6,6 @@ observability:
   alerts:
     enabled: true
     team: dsx
-    runbookUrl: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/dsx-agent-gateway/README.md
 
 agentgateway:
   monitoring:

--- a/local/agent-gateway/values/values.local.yaml
+++ b/local/agent-gateway/values/values.local.yaml
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # CSC local profile.
+observability:
+  alerts:
+    enabled: true
+
 agentgateway:
   discoveryNamespaceSelectors:
     - matchLabels:

--- a/local/agent-gateway/values/values.local.yaml
+++ b/local/agent-gateway/values/values.local.yaml
@@ -5,8 +5,15 @@
 observability:
   alerts:
     enabled: true
+    team: dsx
+    runbookUrl: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/dsx-agent-gateway/README.md
 
 agentgateway:
+  monitoring:
+    grafanaDashboard:
+      enabled: true
+      labels:
+        grafana_dashboard: "1"
   discoveryNamespaceSelectors:
     - matchLabels:
         kubernetes.io/metadata.name: csc-dsx-agentgateway

--- a/local/event-bus/k8s/csc/values.yaml
+++ b/local/event-bus/k8s/csc/values.yaml
@@ -11,6 +11,8 @@
 global:
   eventBus:
     clusterType: csc
+    alerts:
+      enabled: true
     # List of CPC IDs that will connect as leaves
     cpcIds: ["1", "2"]
     gateway:

--- a/local/event-bus/k8s/csc/values.yaml
+++ b/local/event-bus/k8s/csc/values.yaml
@@ -14,7 +14,6 @@ global:
     alerts:
       enabled: true
       team: dsx
-      runbookUrl: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/README.md
     # List of CPC IDs that will connect as leaves
     cpcIds: ["1", "2"]
     gateway:

--- a/local/event-bus/k8s/csc/values.yaml
+++ b/local/event-bus/k8s/csc/values.yaml
@@ -13,6 +13,8 @@ global:
     clusterType: csc
     alerts:
       enabled: true
+      team: dsx
+      runbookUrl: https://github.com/NVIDIA/dsx-exchange/blob/main/deploy/README.md
     # List of CPC IDs that will connect as leaves
     cpcIds: ["1", "2"]
     gateway:
@@ -77,3 +79,11 @@ global:
                 allow: ["test.>"]
         noauth:
           account: "CSC"
+
+surveyor:
+  grafanaDashboard:
+    enabled: true
+    labels:
+      grafana_dashboard: "1"
+    annotations:
+      grafana.com/dashboard-folder: DSX Event Bus

--- a/local/event-bus/k8s/csc/values.yaml
+++ b/local/event-bus/k8s/csc/values.yaml
@@ -14,6 +14,12 @@ global:
     alerts:
       enabled: true
       team: dsx
+    grafanaDashboard:
+      enabled: true
+      labels:
+        grafana_dashboard: "1"
+      annotations:
+        grafana.com/dashboard-folder: DSX Event Bus
     # List of CPC IDs that will connect as leaves
     cpcIds: ["1", "2"]
     gateway:
@@ -78,11 +84,3 @@ global:
                 allow: ["test.>"]
         noauth:
           account: "CSC"
-
-surveyor:
-  grafanaDashboard:
-    enabled: true
-    labels:
-      grafana_dashboard: "1"
-    annotations:
-      grafana.com/dashboard-folder: DSX Event Bus

--- a/local/infra/prometheus/values.yaml
+++ b/local/infra/prometheus/values.yaml
@@ -20,6 +20,7 @@ nodeExporter:
 
 prometheus:
   prometheusSpec:
+    ruleSelectorNilUsesHelmValues: false
     serviceMonitorSelectorNilUsesHelmValues: false
     podMonitorSelectorNilUsesHelmValues: false
     retention: 1h

--- a/scripts/license.sh
+++ b/scripts/license.sh
@@ -51,6 +51,7 @@ args=(
 	-ignore '**/vendor/**'
 	-ignore 'auth-callout/vault-agent/templates/**'
 	-ignore 'deploy/**/charts/**'
+	-ignore 'deploy/nats-event-bus/dashboards/nats-surveyor-dashboard.json'
 	-ignore 'docs/schema-viewer/**'
 	-ignore 'LICENSE'
 	-ignore 'local/**/charts/**/charts/**'


### PR DESCRIPTION
## Summary

- package the unchanged NATS Surveyor v0.9.7 dashboard
- enable the upstream Agent Gateway v1.4.1 dashboard
- add six NATS and six Agent Gateway alerts
- keep dashboards and alerts disabled by default
- document discovery metadata, alert ownership, and enablement

## Validation

- `make check` passed
- generic defaults omit dashboards and alert rules
- CSC values render both dashboards and rules with configured metadata
- explicit CPC enablement renders its alert rule in the CPC namespace
- the NATS dashboard matches Surveyor v0.9.7 byte for byte
- dashboard queries were validated and ytl-dev2 compatibility was checked
- hosted CI, Kind E2E, and CodeRabbit passed on `00aa1a1`
