### PR TITLE
fix(agentgateway): cancel test request context

### DIFF
--- a/dsx-agentgateway-bridge/internal/hub/hub_leaf_test.go
+++ b/dsx-agentgateway-bridge/internal/hub/hub_leaf_test.go
@@ -606,6 +606,7 @@ func TestHubStopsRetryingStreamReadWhenRequestCancels(t *testing.T) {
 		streamSubject: {err: nats.ErrTimeout},
 	})
 	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
 	req := httptest.NewRequest(http.MethodPost, "http://bridge/mcp", nil).WithContext(ctx)
 	done := make(chan error, 1)
 


### PR DESCRIPTION
## Summary

- always cancel the request context in `TestHubStopsRetryingStreamReadWhenRequestCancels`
- satisfy the `lostcancel` check enabled by the upgraded Go lint toolchain

## Root cause

An early test failure path could return without calling `cancel`, so golangci-lint v2.11.4
reported a possible context leak. PR #97's synthetic-branch CI caught the issue before merge,
but the repository ruleset did not require that failing check.

CI enforcement will be configured separately through the existing `main` repository ruleset.

## Validation

- `go -C dsx-agentgateway-bridge test ./...`
- `golangci-lint v2.11.4 run` (`0 issues`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved stream-read cancellation test cleanup to ensure cancellations are handled reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->