### PR TITLE
chore: repoint CODEOWNERS teams to dsx-ai-factory (post-transfer)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # Default: DSX developers team reviews all changes
-* @NVIDIA/dsx-sw-developers
+* @dsx-ai-factory/dsx-sw-developers
 
 # CI/CD workflow changes require additional review
-.github/ @NVIDIA/dsx-sw-admins
+.github/ @dsx-ai-factory/dsx-sw-admins
 
 # Security-sensitive files
-SECURITY.md @NVIDIA/dsx-sw-admins
+SECURITY.md @dsx-ai-factory/dsx-sw-admins


### PR DESCRIPTION
## What
Repoint `.github/CODEOWNERS` team references from the old `@NVIDIA/` org to `@dsx-ai-factory/` now that the repo has been SCM-transferred.

```
- * @NVIDIA/dsx-sw-developers
- .github/ @NVIDIA/dsx-sw-admins
- SECURITY.md @NVIDIA/dsx-sw-admins
+ * @dsx-ai-factory/dsx-sw-developers
+ .github/ @dsx-ai-factory/dsx-sw-admins
+ SECURITY.md @dsx-ai-factory/dsx-sw-admins
```

## Why
Teams are org-scoped and don't travel across an SCM transfer. While the file still referenced `@NVIDIA/...`, code-owner review no longer resolved in `dsx-ai-factory` (owners silently unenforced). Both teams already exist in the new org (IdP-synced) and have been re-granted on this repo (`dsx-sw-admins`=admin, `dsx-sw-developers`=push).

## Notes
- Opened from a personal fork because this repo blocks in-repo branch creation (ruleset); no fork is created in the production org.
- Will be squash-merged (repo enforces linear history + signed commits; the squash commit is GitHub-signed).
- Keep "Require review from Code Owners" enabled so this routes to the teams.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership assignments for default, CI/CD, and security-sensitive file reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->