### PR TITLE
chore: point shared actions at current repo path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,14 +31,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: NVIDIA/dsx-github-actions/.github/actions/commitlint@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/commitlint@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
 
   license-headers:
     name: License Headers
     runs-on: linux-amd64-cpu4
     steps:
       - uses: actions/checkout@v4
-      - uses: NVIDIA/dsx-github-actions/.github/actions/license-headers@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/license-headers@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
         with:
           license: apache
           copyright-holder: "NVIDIA CORPORATION & AFFILIATES. All rights reserved."
@@ -63,7 +63,7 @@ jobs:
     runs-on: linux-amd64-cpu4
     steps:
       - uses: actions/checkout@v4
-      - uses: NVIDIA/dsx-github-actions/.github/actions/go-lint@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/go-lint@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
         with:
           go-flags: "-mod=vendor"
           working-directory: auth-callout
@@ -73,7 +73,7 @@ jobs:
     runs-on: linux-amd64-cpu4
     steps:
       - uses: actions/checkout@v4
-      - uses: NVIDIA/dsx-github-actions/.github/actions/go-test@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/go-test@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
         with:
           go-flags: "-mod=vendor"
           test-flags: "-v -count=1 -timeout=10m"
@@ -113,7 +113,7 @@ jobs:
     runs-on: linux-amd64-cpu4
     steps:
       - uses: actions/checkout@v4
-      - uses: NVIDIA/dsx-github-actions/.github/actions/go-lint@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/go-lint@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
         with:
           working-directory: dsx-agentgateway-bridge
 
@@ -122,7 +122,7 @@ jobs:
     runs-on: linux-amd64-cpu4
     steps:
       - uses: actions/checkout@v4
-      - uses: NVIDIA/dsx-github-actions/.github/actions/go-test@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/go-test@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
         with:
           test-flags: "-v -count=1 -timeout=10m"
           working-directory: dsx-agentgateway-bridge
@@ -151,7 +151,7 @@ jobs:
     runs-on: linux-amd64-cpu4
     steps:
       - uses: actions/checkout@v4
-      - uses: NVIDIA/dsx-github-actions/.github/actions/docker-build@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/docker-build@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
         with:
           image: dsx-exchange-auth-callout
           tags: ci-validation
@@ -165,7 +165,7 @@ jobs:
     runs-on: linux-amd64-cpu4
     steps:
       - uses: actions/checkout@v4
-      - uses: NVIDIA/dsx-github-actions/.github/actions/docker-build@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/docker-build@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
         with:
           image: dsx-agentgateway-bridge
           tags: ci-validation
@@ -189,7 +189,7 @@ jobs:
         with:
           go-version-file: auth-callout/go.mod
           cache: false
-      - uses: NVIDIA/dsx-github-actions/.github/actions/codeql-scan@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/codeql-scan@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
         with:
           languages: go
           build-mode: manual
@@ -209,7 +209,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: NVIDIA/dsx-github-actions/.github/actions/trufflehog-scan@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/trufflehog-scan@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
         with:
           post-pr-comment: "true"
           fail-on-findings: "true"
@@ -220,7 +220,7 @@ jobs:
     runs-on: linux-amd64-cpu4
     steps:
       - uses: actions/checkout@v4
-      - uses: NVIDIA/dsx-github-actions/.github/actions/docker-build@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/docker-build@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
         with:
           image: dsx-exchange-auth-callout
           tags: scan-validation
@@ -228,7 +228,7 @@ jobs:
           dockerfile: auth-callout/build/package/Dockerfile
           platforms: linux/amd64
           push: "false"
-      - uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/security-container-scan@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
         with:
           image: dsx-exchange-auth-callout:scan-validation
 
@@ -237,7 +237,7 @@ jobs:
     runs-on: linux-amd64-cpu4
     steps:
       - uses: actions/checkout@v4
-      - uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-validate@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
         with:
           chart-path: auth-callout/deploy
           helm-version: v4.2.2
@@ -258,7 +258,7 @@ jobs:
           path: .cache
           key: local-dependencies-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('local/scripts/prepare-dependencies.sh', 'local/scripts/cache-*.sh') }}
       - run: mise exec -- bash local/scripts/prepare-dependencies.sh
-      - uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-validate@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
         with:
           chart-path: deploy/nats-event-bus
           helm-version: v4.2.2
@@ -314,7 +314,7 @@ jobs:
       CI_STATUS: ${{ contains(needs.*.result, 'failure') && 'FAILED' || 'PASSED' }}
       RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
-      - uses: NVIDIA/dsx-github-actions/.github/actions/slack-notify@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/slack-notify@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
         with:
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: C09VC8R4E92

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - uses: NVIDIA/dsx-github-actions/.github/actions/semantic-release@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/semantic-release@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-plugins: conventional-changelog-conventionalcommits

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,4 +18,4 @@ jobs:
     name: Mark Stale Issues and PRs
     runs-on: linux-amd64-cpu4
     steps:
-      - uses: NVIDIA/dsx-github-actions/.github/actions/stale-check@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/stale-check@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0


### PR DESCRIPTION
The workflows reference the shared composite actions by their full `owner/repo` path, which currently only resolves through a redirect. This repoints them to the current path so they resolve directly and no longer depend on a redirect staying in place.

All references keep the same pinned SHA (`v1.17.0`) — path only, no behavior change.

- `.github/workflows/ci.yml`
- `.github/workflows/release.yml`
- `.github/workflows/stale.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build, release, security-scan, and stale-check workflows to use the maintained shared Actions source.
  * Preserved existing workflow behavior, version pinning, and security scanning steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->