### PR TITLE
docs: update for new github org

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ make test
 
 ## Checklist
 
-- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/dsx-exchange/blob/main/CONTRIBUTING.md).
+- [ ] I am familiar with the [Contributing Guidelines](https://github.com/dsx-ai-factory/dsx-exchange/blob/main/CONTRIBUTING.md).
 - [ ] Documentation updated, if needed.
 - [ ] Tests or validation added/updated, if needed.
 - [ ] License headers are present on applicable source files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Fork and clone the repository:
 ```bash
 git clone https://github.com/<your-username>/dsx-exchange.git
 cd dsx-exchange
-git remote add upstream https://github.com/NVIDIA/dsx-exchange.git
+git remote add upstream https://github.com/dsx-ai-factory/dsx-exchange.git
 ```
 
 Keep changes focused. Use a separate branch for each concern:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Clone the repository, install the local e2e prerequisites, and run the local
 validation checks:
 
 ```bash
-git clone https://github.com/NVIDIA/dsx-exchange.git
+git clone https://github.com/dsx-ai-factory/dsx-exchange.git
 cd dsx-exchange
 mise install --locked
 make test
@@ -97,7 +97,7 @@ DSX Exchange follows [Semantic Versioning](https://semver.org/) (`vX.Y.Z`), auto
 
 ### Roadmap
 
-Upcoming work is tracked in [GitHub Issues](https://github.com/NVIDIA/dsx-exchange/issues). See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get involved.
+Upcoming work is tracked in [GitHub Issues](https://github.com/dsx-ai-factory/dsx-exchange/issues). See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get involved.
 
 ## Contribution Guidelines
 
@@ -107,7 +107,7 @@ Upcoming work is tracked in [GitHub Issues](https://github.com/NVIDIA/dsx-exchan
 Development quickstart:
 
 ```bash
-git clone https://github.com/NVIDIA/dsx-exchange.git
+git clone https://github.com/dsx-ai-factory/dsx-exchange.git
 cd dsx-exchange
 mise install --locked
 make test

--- a/auth-callout/.pre-commit-config.yaml
+++ b/auth-callout/.pre-commit-config.yaml
@@ -133,7 +133,7 @@ repos:
         stages: [pre-commit]
         args:
           - -w
-          - -local=github.com/NVIDIA/dsx-exchange
+          - -local=github.com/dsx-ai-factory/dsx-exchange
           - -d=false
       #   - id: go-imports-repo # replaces go-fmt-repo
       #   - id: go-returns # replaces go-imports & go-fmt

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,7 @@ DSX Exchange consists of three components:
 | Auth-Callout Service | OAuth2/mTLS/NKey authentication with topic-level ACLs |
 
 <Info title="GitHub Repository">
-  The DSX Exchange GitHub repository is available at [https://github.com/NVIDIA/dsx-exchange](https://github.com/NVIDIA/dsx-exchange).
+  The DSX Exchange GitHub repository is available at [https://github.com/dsx-ai-factory/dsx-exchange](https://github.com/dsx-ai-factory/dsx-exchange).
 </Info>
 
 ## DSX Event Bus

--- a/docs/pre-deployment.md
+++ b/docs/pre-deployment.md
@@ -5,7 +5,7 @@ Everything that must be in place before deploying the DSX Event Bus. This covers
 **Estimated time**: The production path (secrets pipeline + certificates) takes 4–6 hours for a first-time deployment across 1 CSC + 2 CPCs. The evaluation path (`local/` Makefile) takes ~10 minutes. See [Deployment — Evaluation Install](getting-started.md) for the quick-start option.
 
 <Info title="GitHub Repository">
-  The DSX Exchange GitHub repository is available at [https://github.com/NVIDIA/dsx-exchange](https://github.com/NVIDIA/dsx-exchange).
+  The DSX Exchange GitHub repository is available at [https://github.com/dsx-ai-factory/dsx-exchange](https://github.com/dsx-ai-factory/dsx-exchange).
 </Info>
 
 ## Host Prerequisites

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -13,6 +13,10 @@ instances:
 
 title: DSX Exchange
 
+navbar-links:
+  - type: github
+    value: https://github.com/dsx-ai-factory/dsx-exchange
+
 announcement:
   message: "🔔 DSX Exchange is a <strong>developer preview</strong>. APIs and behavior may change without notice."
 
@@ -26,14 +30,6 @@ check:
 
 settings:
   folder-title-source: frontmatter
-
-layout:
-  searchbar-placement: header
-  page-width: 1376px
-  sidebar-width: 248px
-  content-width: 812px
-  tabs-placement: header
-  hide-feedback: true
 
 navigation:
   - section: DSX Exchange


### PR DESCRIPTION
Update various docs and other URLs to point to the new GitHub org. This is nowhere near all of them: I left most files (*.go, *.mod, *.yaml, Dockerfile, and THIRD_PARTY_LICENSES.*) alone.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/dsx-exchange/blob/main/CONTRIBUTING.md).
- [x] Documentation updated, if needed.
- [x] Tests or validation added/updated, if needed.
- [x] License headers are present on applicable source files.
- [x] Third-party license inventory updated, if dependencies changed.
- [x] Security-sensitive changes were reviewed privately before public disclosure.
- [x] My commits are signed off (`git commit -s`) per the DCO.
