### PR TITLE
refactor(auth-callout): use context-driven shutdown

### DIFF
--- a/auth-callout/src/cmd/auth_callout/main.go
+++ b/auth-callout/src/cmd/auth_callout/main.go
@@ -8,6 +8,9 @@ import (
 	_ "embed"
 	"fmt"
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/spf13/cobra"
 
@@ -55,8 +58,8 @@ var generateCmd = &cobra.Command{
 // runServer is the main entry point for running the service.
 // It loads configuration, sets up logging, tracing, and metrics, then creates
 // and runs the service instance.
-func runServer(_ *cobra.Command, _ []string) error {
-	ctx := context.Background()
+func runServer(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
 	cfgManager := globalConfig
 
 	if err := cfgManager.Load(); err != nil {
@@ -89,10 +92,13 @@ func runServer(_ *cobra.Command, _ []string) error {
 
 	// Create and run server
 	svc := service.New(svcConfig, logger)
-	return svc.Run()
+	return svc.Run(ctx)
 }
 
 func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	globalConfig = appconfig.New(defaultConfigYAML)
 	globalConfig.BindFlags(rootCmd)
 
@@ -100,7 +106,7 @@ func main() {
 	rootCmd.AddCommand(generateCmd)
 
 	// Execute the root command
-	if err := rootCmd.Execute(); err != nil {
+	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		log.Fatalf("Failed to execute: %v", err)
 	}
 }

--- a/auth-callout/src/cmd/auth_callout/main_test.go
+++ b/auth-callout/src/cmd/auth_callout/main_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/nats-io/nkeys"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
 	"github.com/NVIDIA/dsx-exchange/auth-callout/src/internal/appconfig"
@@ -34,7 +35,7 @@ func TestRunServerDoesNotLogConfiguredNATSSeeds(t *testing.T) {
 
 	logs := captureStderr(t, func() {
 		globalConfig = appconfig.New(defaultConfigYAML)
-		err := runServer(nil, nil)
+		err := runServer(&cobra.Command{}, nil)
 		require.ErrorContains(t, err, "error connecting to NATS")
 	})
 

--- a/auth-callout/src/internal/service/service.go
+++ b/auth-callout/src/internal/service/service.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"os/signal"
-	"syscall"
 	"time"
 
 	gorillaHandlers "github.com/gorilla/handlers"
@@ -210,10 +208,10 @@ func newHTTPServer(addr string, handler http.Handler, logger *zap.Logger) *http.
 	}
 }
 
-// Run starts the HTTP server and handles graceful shutdown on SIGINT or SIGTERM signals.
+// Run starts the HTTP server and handles graceful shutdown when ctx is canceled.
 // It sets up routes including health checks and authentication middleware.
-// The service will wait for interrupt signals and perform a graceful shutdown with a 5-second timeout.
-func (s *Service) Run() error {
+// The service waits for context cancellation and performs a graceful shutdown with a 5-second timeout.
+func (s *Service) Run(ctx context.Context) error {
 	// =================================================
 	// Put unauthenticated health routes here.
 	// =================================================
@@ -249,10 +247,10 @@ func (s *Service) Run() error {
 
 	// Create authorization handler
 	authorizerFn := func(req *jwt.AuthorizationRequest) (string, error) {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		requestCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
-		ctx = obslogging.AttachLoggerToContext(ctx, s.logger)
-		return s.handleAuthRequest(ctx, req)
+		requestCtx = obslogging.AttachLoggerToContext(requestCtx, s.logger)
+		return s.handleAuthRequest(requestCtx, req)
 	}
 
 	// Configure callout service options
@@ -287,10 +285,7 @@ func (s *Service) Run() error {
 		}
 	}()
 
-	// Handle interrupts
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-	<-sigChan
+	<-ctx.Done()
 
 	// Graceful shutdown
 	s.logger.Warn("service is shutting down...")

--- a/auth-callout/src/internal/service/service.go
+++ b/auth-callout/src/internal/service/service.go
@@ -208,9 +208,8 @@ func newHTTPServer(addr string, handler http.Handler, logger *zap.Logger) *http.
 	}
 }
 
-// Run starts the HTTP server and handles graceful shutdown when ctx is canceled.
-// It sets up routes including health checks and authentication middleware.
-// The service waits for context cancellation and performs a graceful shutdown with a 5-second timeout.
+// Run starts the service and gracefully shuts it down when ctx is canceled.
+// HTTP shutdown is limited to five seconds.
 func (s *Service) Run(ctx context.Context) error {
 	// =================================================
 	// Put unauthenticated health routes here.

--- a/auth-callout/src/internal/service/service.go
+++ b/auth-callout/src/internal/service/service.go
@@ -247,10 +247,10 @@ func (s *Service) Run(ctx context.Context) error {
 
 	// Create authorization handler
 	authorizerFn := func(req *jwt.AuthorizationRequest) (string, error) {
-		requestCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
-		requestCtx = obslogging.AttachLoggerToContext(requestCtx, s.logger)
-		return s.handleAuthRequest(requestCtx, req)
+		ctx = obslogging.AttachLoggerToContext(ctx, s.logger)
+		return s.handleAuthRequest(ctx, req)
 	}
 
 	// Configure callout service options

--- a/auth-callout/src/internal/service/service.go
+++ b/auth-callout/src/internal/service/service.go
@@ -305,10 +305,10 @@ func (s *Service) Run(ctx context.Context) error {
 		s.logger.Error("error closing permissions manager", zap.Error(err))
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if err := s.server.Shutdown(ctx); err != nil {
+	if err := s.server.Shutdown(shutdownCtx); err != nil {
 		errMsg := fmt.Sprintf("service shutdown failed: %s", err.Error())
 		s.logger.Error(errMsg, zap.Error(err))
 	} else {

--- a/auth-callout/src/internal/service/service_test.go
+++ b/auth-callout/src/internal/service/service_test.go
@@ -4,20 +4,60 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/nats-io/jwt/v2"
 	natsserver "github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nkeys"
+	"github.com/stretchr/testify/require"
 	"github.com/synadia-io/callout.go"
 	"github.com/uptrace/opentelemetry-go-extra/otelzap"
 	"go.uber.org/zap"
 )
+
+func TestRunStopsWhenContextCanceled(t *testing.T) {
+	natsServer := runNATSServer(t)
+	permissionsFile := filepath.Join(t.TempDir(), "permissions.json")
+	require.NoError(t, os.WriteFile(permissionsFile, []byte(`{}`), 0o600))
+
+	issuerKeyPair, err := nkeys.CreateAccount()
+	require.NoError(t, err)
+	issuerSeed, err := issuerKeyPair.Seed()
+	require.NoError(t, err)
+
+	svc := New(ServiceConfig{
+		HostConfig: HostConfig{Port: 0},
+		NATS: NATSConfig{
+			URL:        natsServer.ClientURL(),
+			IssuerSeed: string(issuerSeed),
+		},
+		Permissions: PermissionsFileConfig{File: permissionsFile},
+	}, otelzap.New(zap.NewNop()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.Run(ctx)
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("service did not stop after context cancellation")
+	}
+}
 
 func TestAuthorizationServiceStartsBeforeInitialNATSConnect(t *testing.T) {
 	natsServer := runNATSServer(t)

--- a/auth-callout/src/internal/service/service_test.go
+++ b/auth-callout/src/internal/service/service_test.go
@@ -54,6 +54,11 @@ func TestRunStopsWhenContextCanceled(t *testing.T) {
 	select {
 	case err := <-done:
 		require.NoError(t, err)
+		require.True(
+			t,
+			svc.natsConn.IsDraining() || svc.natsConn.IsClosed(),
+			"NATS connection was not drained",
+		)
 	case <-time.After(2 * time.Second):
 		t.Fatal("service did not stop after context cancellation")
 	}


### PR DESCRIPTION
## Summary

- handle SIGINT and SIGTERM in the auth-callout entry point
- pass the lifecycle context through Cobra to `Service.Run`
- cancel in-flight authorization requests when the service shuts down
- add embedded NATS coverage for context-driven shutdown

## Motivation

The bridge already manages shutdown through a context created at the process
entry point. This aligns auth-callout with that lifecycle pattern without
integrating the two services or changing normal authentication behavior.

## Validation

- `make -C auth-callout test`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service shutdown handling when interrupted or requested to stop.
  * Authorization requests now honor cancellation and timeout signals.
  * Improved reliability of graceful shutdown operations during cancellation.
  * Service shutdown now completes within the configured graceful termination window.

* **Tests**
  * Added coverage confirming the service exits cleanly after cancellation.
  * Added verification that active connections begin draining or close during shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->