### PR TITLE
fix(auth-callout): enforce container security context

### DIFF
--- a/auth-callout/deploy/templates/deployment.yaml
+++ b/auth-callout/deploy/templates/deployment.yaml
@@ -62,6 +62,12 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           args:
             - "--config"
             - "/etc/config/config.yaml"


### PR DESCRIPTION
## Description

Require the auth-callout container to run as non-root, disable privilege escalation, and drop all Linux capabilities.

The security context is container-scoped so injected sidecars are unaffected.

## Validation

- `LC_ALL=C make check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Improved deployment security by running the container as a non-root user.
  * Disabled privilege escalation and dropped unnecessary Linux capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->