### PR TITLE
chore: scope dsx-exchange CODEOWNERS to project team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
-# Default: DSX developers team reviews all changes
-* @dsx-ai-factory/dsx-sw-developers
+# Default: dsx-exchange project team reviews all changes
+* @dsx-ai-factory/dsx-exchange
 
-# CI/CD workflow changes require additional review
-.github/ @dsx-ai-factory/dsx-sw-admins
+# CI/CD workflow changes
+.github/ @dsx-ai-factory/dsx-exchange
 
 # Security-sensitive files
-SECURITY.md @dsx-ai-factory/dsx-sw-admins
+SECURITY.md @dsx-ai-factory/dsx-exchange


### PR DESCRIPTION
Repoints CODEOWNERS from the org-wide `dsx-sw-developers` / `dsx-sw-admins` teams to the new project-scoped `@dsx-ai-factory/dsx-exchange` team, so review/merge is owned by the engineers working on this repo.

- `*` -> `@dsx-ai-factory/dsx-exchange`
- `.github/` -> `@dsx-ai-factory/dsx-exchange`
- `SECURITY.md` -> `@dsx-ai-factory/dsx-exchange`

Phase 1 of the dsx-exchange self-management handoff. The `dsx-exchange` team is manually managed for now (Bora as maintainer) and will be DL-synced in Phase 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership assignments for general changes, CI/CD workflow files, and security documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->