### PR TITLE
fix(auth-callout): require HTTPS for JWKS

### DIFF
--- a/auth-callout/README.md
+++ b/auth-callout/README.md
@@ -33,6 +33,7 @@ jwks:
   url: "https://keycloak/realms/master/protocol/openid-connect/certs"
   issuer: "https://keycloak/realms/master"
   audience: "dsx-exchange"
+  allow-insecure: false
   signing-algorithms:
     - RS256
     - ES256

--- a/auth-callout/api/env.example
+++ b/auth-callout/api/env.example
@@ -10,3 +10,4 @@ JWKS_URL=http://keycloak.127-0-0-1.nip.io:8080/realms/auth-callout/protocol/open
 JWKS_ISSUER=http://keycloak.127-0-0-1.nip.io:8080/realms/auth-callout
 JWKS_AUDIENCE=dsx-exchange
 JWKS_SIGNING_ALGORITHMS=RS256
+JWKS_ALLOW_INSECURE=true

--- a/auth-callout/deploy/README.md
+++ b/auth-callout/deploy/README.md
@@ -84,6 +84,7 @@ serviceConfig:
     url: "https://keycloak/realms/master/protocol/openid-connect/certs"
     issuer: "https://keycloak/realms/master"
     audience: "dsx-exchange"
+    allow-insecure: false
     signing-algorithms:
       - RS256
       - ES256

--- a/auth-callout/deploy/values.yaml
+++ b/auth-callout/deploy/values.yaml
@@ -218,6 +218,7 @@ serviceConfig:
     url: ""            # JWKS endpoint URL (e.g., "https://auth.example.com/.well-known/jwks.json")
     issuer: ""         # Expected JWT issuer
     audience: ""       # Expected JWT audience
+    allow-insecure: false # Allow HTTP JWKS endpoints
 
   # mTLS configuration
   mtls:

--- a/auth-callout/env.example
+++ b/auth-callout/env.example
@@ -10,6 +10,7 @@ JWKS_URL=http://keycloak.127-0-0-1.nip.io:8080/realms/auth-callout/protocol/open
 JWKS_ISSUER=http://keycloak.127-0-0-1.nip.io:8080/realms/auth-callout
 JWKS_AUDIENCE=dsx-exchange
 JWKS_SIGNING_ALGORITHMS=RS256
+JWKS_ALLOW_INSECURE=true
 
 # NATS keys are secrets and must come from Vault or generated local files.
 # Generate development values with scripts/devspace-get-key.sh or nsc.

--- a/auth-callout/src/cmd/auth_callout/config/defaults.yaml
+++ b/auth-callout/src/cmd/auth_callout/config/defaults.yaml
@@ -16,6 +16,7 @@ jwks:
   url: ""            # JWKS endpoint URL
   issuer: ""         # Expected JWT issuer
   audience: ""       # Expected JWT audience
+  allow-insecure: false # Allow HTTP JWKS endpoints
   signing-algorithms:
     - RS256          # Allowed JWT signing algorithms
 

--- a/auth-callout/src/cmd/auth_callout/main_test.go
+++ b/auth-callout/src/cmd/auth_callout/main_test.go
@@ -43,7 +43,7 @@ func TestRunServerDoesNotLogConfiguredNATSSeeds(t *testing.T) {
 	}
 }
 
-func TestDefaultConfigIncludesJWKSSigningAlgorithms(t *testing.T) {
+func TestDefaultConfigIncludesJWKSSettings(t *testing.T) {
 	// Load overlays env and config-file sources after defaultConfigYAML; clear
 	// those inputs so this test only proves the embedded app defaults.
 	t.Setenv("AUTH_CALLOUT_CONFIG", "")
@@ -51,6 +51,8 @@ func TestDefaultConfigIncludesJWKSSigningAlgorithms(t *testing.T) {
 	t.Setenv("AUTH_CALLOUT_HOT_CONFIG", "")
 	t.Setenv("AUTH_CALLOUT_JWKS_SIGNING_ALGORITHMS", "")
 	t.Setenv("JWKS_SIGNING_ALGORITHMS", "")
+	t.Setenv("AUTH_CALLOUT_JWKS_ALLOW_INSECURE", "")
+	t.Setenv("JWKS_ALLOW_INSECURE", "")
 
 	manager := appconfig.New(defaultConfigYAML)
 	require.NoError(t, manager.Load())
@@ -58,11 +60,13 @@ func TestDefaultConfigIncludesJWKSSigningAlgorithms(t *testing.T) {
 	type jwksConfig struct {
 		JWKS struct {
 			SigningAlgorithms []string `koanf:"signing-algorithms"`
+			AllowInsecure     bool     `koanf:"allow-insecure"`
 		} `koanf:"jwks"`
 	}
 	var config jwksConfig
 	require.NoError(t, manager.Unmarshal(&config))
 	require.Equal(t, []string{"RS256"}, config.JWKS.SigningAlgorithms)
+	require.False(t, config.JWKS.AllowInsecure)
 }
 
 func captureStderr(t *testing.T, fn func()) string {

--- a/auth-callout/src/internal/appconfig/manager.go
+++ b/auth-callout/src/internal/appconfig/manager.go
@@ -109,6 +109,7 @@ func applyAliases(k *koanf.Koanf) {
 	setString(k, "jwks.issuer", "JWKS_ISSUER", envPrefix+"JWKS_ISSUER")
 	setString(k, "jwks.audience", "JWKS_AUDIENCE", envPrefix+"JWKS_AUDIENCE")
 	setStringSlice(k, "jwks.signing-algorithms", "JWKS_SIGNING_ALGORITHMS", envPrefix+"JWKS_SIGNING_ALGORITHMS")
+	setString(k, "jwks.allow-insecure", "JWKS_ALLOW_INSECURE", envPrefix+"JWKS_ALLOW_INSECURE")
 	setString(k, "mtls.ca-path", "MTLS_CA_PATH", envPrefix+"MTLS_CA_PATH")
 	setString(k, "permissions.file", "PERMISSIONS_FILE", envPrefix+"PERMISSIONS_FILE")
 	setString(k, "observability.telemetry.service-name", envPrefix+"SERVICE_NAME")

--- a/auth-callout/src/internal/appconfig/manager_test.go
+++ b/auth-callout/src/internal/appconfig/manager_test.go
@@ -38,8 +38,9 @@ nats:
 	require.Equal(t, "SXFAKE", config.NATS.XKeySeed)
 }
 
-func TestLoadAllowsJWKSAlgorithmsInEnvironment(t *testing.T) {
+func TestLoadAllowsJWKSConfigInEnvironment(t *testing.T) {
 	t.Setenv("AUTH_CALLOUT_JWKS_SIGNING_ALGORITHMS", "RS256,ES256")
+	t.Setenv("AUTH_CALLOUT_JWKS_ALLOW_INSECURE", "true")
 
 	manager := New("")
 	require.NoError(t, manager.Load())
@@ -47,11 +48,13 @@ func TestLoadAllowsJWKSAlgorithmsInEnvironment(t *testing.T) {
 	type jwksConfig struct {
 		JWKS struct {
 			SigningAlgorithms []string `koanf:"signing-algorithms"`
+			AllowInsecure     bool     `koanf:"allow-insecure"`
 		} `koanf:"jwks"`
 	}
 	var config jwksConfig
 	require.NoError(t, manager.Unmarshal(&config))
 	require.Equal(t, []string{"RS256", "ES256"}, config.JWKS.SigningAlgorithms)
+	require.True(t, config.JWKS.AllowInsecure)
 }
 
 func writeConfigFile(t *testing.T, name, content string) string {

--- a/auth-callout/src/internal/auth/auth_test.go
+++ b/auth-callout/src/internal/auth/auth_test.go
@@ -109,6 +109,9 @@ func TestNewOAuth2AuthenticatorRejectsHTTPSDowngrade(t *testing.T) {
 	redirectServer := httptest.NewTLSServer(http.RedirectHandler(targetServer.URL, http.StatusFound))
 	defer redirectServer.Close()
 
+	initialServer := httptest.NewServer(http.RedirectHandler(redirectServer.URL, http.StatusFound))
+	defer initialServer.Close()
+
 	defaultTransport := http.DefaultTransport
 	http.DefaultTransport = redirectServer.Client().Transport
 	defer func() {
@@ -116,11 +119,11 @@ func TestNewOAuth2AuthenticatorRejectsHTTPSDowngrade(t *testing.T) {
 	}()
 
 	oauth2Auth, err := NewOAuth2Authenticator(
-		redirectServer.URL,
+		initialServer.URL,
 		"https://auth.example.com/",
 		"test-audience",
 		[]string{gojwt.SigningMethodRS256.Alg()},
-		false,
+		true,
 		nil,
 		testLogger(),
 		testServiceName,

--- a/auth-callout/src/internal/auth/auth_test.go
+++ b/auth-callout/src/internal/auth/auth_test.go
@@ -84,6 +84,57 @@ func TestValidateOAuth2SigningAlgorithms(t *testing.T) {
 	}
 }
 
+func TestNewOAuth2AuthenticatorRejectsInsecureJWKSURL(t *testing.T) {
+	_, err := NewOAuth2Authenticator(
+		"http://auth.example.com/jwks",
+		"https://auth.example.com/",
+		"test-audience",
+		[]string{gojwt.SigningMethodRS256.Alg()},
+		false,
+		nil,
+		testLogger(),
+		testServiceName,
+	)
+
+	require.EqualError(t, err, "JWKS URL must use HTTPS")
+}
+
+func TestNewOAuth2AuthenticatorRejectsHTTPSDowngrade(t *testing.T) {
+	targetRequested := make(chan struct{}, 1)
+	targetServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		targetRequested <- struct{}{}
+	}))
+	defer targetServer.Close()
+
+	redirectServer := httptest.NewTLSServer(http.RedirectHandler(targetServer.URL, http.StatusFound))
+	defer redirectServer.Close()
+
+	defaultTransport := http.DefaultTransport
+	http.DefaultTransport = redirectServer.Client().Transport
+	defer func() {
+		http.DefaultTransport = defaultTransport
+	}()
+
+	oauth2Auth, err := NewOAuth2Authenticator(
+		redirectServer.URL,
+		"https://auth.example.com/",
+		"test-audience",
+		[]string{gojwt.SigningMethodRS256.Alg()},
+		false,
+		nil,
+		testLogger(),
+		testServiceName,
+	)
+	require.NoError(t, err)
+	defer oauth2Auth.Close()
+
+	select {
+	case <-targetRequested:
+		t.Fatal("followed HTTPS-to-HTTP redirect")
+	default:
+	}
+}
+
 // TestOAuth2Authentication tests OAuth2/JWKS authentication with mock server
 func TestOAuth2Authentication(t *testing.T) {
 	// Generate RSA key pair for JWT signing
@@ -136,6 +187,7 @@ func TestOAuth2Authentication(t *testing.T) {
 		"https://auth.example.com/",
 		"test-audience",
 		[]string{gojwt.SigningMethodRS256.Alg()},
+		true,
 		pm,
 		testLogger(),
 		testServiceName,
@@ -336,6 +388,7 @@ func TestOAuth2RejectsUnexpectedSigningMethod(t *testing.T) {
 		"https://auth.example.com/",
 		"test-audience",
 		[]string{gojwt.SigningMethodRS256.Alg()},
+		true,
 		pm,
 		testLogger(),
 		testServiceName,
@@ -397,6 +450,7 @@ func TestOAuth2AllowsConfiguredES256SigningMethod(t *testing.T) {
 		"https://auth.example.com/",
 		"test-audience",
 		[]string{gojwt.SigningMethodRS256.Alg(), gojwt.SigningMethodES256.Alg()},
+		true,
 		pm,
 		testLogger(),
 		testServiceName,
@@ -494,6 +548,7 @@ func TestOAuth2RequiredScope(t *testing.T) {
 		"https://auth.example.com/",
 		"test-audience",
 		[]string{gojwt.SigningMethodRS256.Alg()},
+		true,
 		pm,
 		testLogger(),
 		testServiceName,

--- a/auth-callout/src/internal/auth/oauth2.go
+++ b/auth-callout/src/internal/auth/oauth2.go
@@ -120,7 +120,7 @@ func validateJWKSRedirect(req *http.Request, via []*http.Request, allowInsecure 
 	if len(via) >= 10 {
 		return fmt.Errorf("stopped after 10 JWKS redirects")
 	}
-	if len(via) > 0 && via[0].URL.Scheme == "https" && req.URL.Scheme != "https" {
+	if len(via) > 0 && via[len(via)-1].URL.Scheme == "https" && req.URL.Scheme != "https" {
 		return fmt.Errorf("JWKS redirects must not downgrade HTTPS to HTTP")
 	}
 

--- a/auth-callout/src/internal/auth/oauth2.go
+++ b/auth-callout/src/internal/auth/oauth2.go
@@ -6,6 +6,8 @@ package auth
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
 	"slices"
 	"strings"
 
@@ -47,7 +49,7 @@ var supportedOAuth2SigningAlgorithms = map[string]struct{}{
 }
 
 // NewOAuth2Authenticator creates a new OAuth2 authenticator
-func NewOAuth2Authenticator(jwksURL string, issuer string, audience string, signingAlgorithms []string, pm *config.PermissionsManager, logger *otelzap.Logger, serviceName string) (*OAuth2Authenticator, error) {
+func NewOAuth2Authenticator(jwksURL string, issuer string, audience string, signingAlgorithms []string, allowInsecureJWKS bool, pm *config.PermissionsManager, logger *otelzap.Logger, serviceName string) (*OAuth2Authenticator, error) {
 	if issuer == "" {
 		return nil, fmt.Errorf("OAuth2 issuer is required")
 	}
@@ -57,10 +59,19 @@ func NewOAuth2Authenticator(jwksURL string, issuer string, audience string, sign
 	if err := validateOAuth2SigningAlgorithms(signingAlgorithms); err != nil {
 		return nil, err
 	}
+	if err := validateJWKSURL(jwksURL, allowInsecureJWKS); err != nil {
+		return nil, err
+	}
+
+	jwksClient := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return validateJWKSRedirect(req, via, allowInsecureJWKS)
+		},
+	}
 
 	// Create JWKS client with automatic refresh - context controls lifecycle
 	ctx, cancel := context.WithCancel(context.Background())
-	k, err := keyfunc.NewDefaultCtx(ctx, []string{jwksURL})
+	k, err := keyfunc.NewDefaultOverrideCtx(ctx, []string{jwksURL}, keyfunc.Override{Client: jwksClient})
 	if err != nil {
 		cancel()
 		return nil, fmt.Errorf("failed to create JWKS client: %w", err)
@@ -81,6 +92,39 @@ func NewOAuth2Authenticator(jwksURL string, issuer string, audience string, sign
 		serviceName:       serviceName,
 		cancel:            cancel,
 	}, nil
+}
+
+func validateJWKSURL(rawURL string, allowInsecure bool) error {
+	parsedURL, err := url.ParseRequestURI(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid JWKS URL: %w", err)
+	}
+	if parsedURL.Host == "" {
+		return fmt.Errorf("invalid JWKS URL: host is required")
+	}
+
+	switch parsedURL.Scheme {
+	case "https":
+		return nil
+	case "http":
+		if allowInsecure {
+			return nil
+		}
+		return fmt.Errorf("JWKS URL must use HTTPS")
+	default:
+		return fmt.Errorf("JWKS URL must use HTTP or HTTPS")
+	}
+}
+
+func validateJWKSRedirect(req *http.Request, via []*http.Request, allowInsecure bool) error {
+	if len(via) >= 10 {
+		return fmt.Errorf("stopped after 10 JWKS redirects")
+	}
+	if len(via) > 0 && via[0].URL.Scheme == "https" && req.URL.Scheme != "https" {
+		return fmt.Errorf("JWKS redirects must not downgrade HTTPS to HTTP")
+	}
+
+	return validateJWKSURL(req.URL.String(), allowInsecure)
 }
 
 func validateOAuth2SigningAlgorithms(configured []string) error {

--- a/auth-callout/src/internal/service/service.go
+++ b/auth-callout/src/internal/service/service.go
@@ -85,6 +85,7 @@ type JWKSConfig struct {
 	Issuer            string   `koanf:"issuer"`
 	Audience          string   `koanf:"audience"`
 	SigningAlgorithms []string `koanf:"signing-algorithms"`
+	AllowInsecure     bool     `koanf:"allow-insecure"`
 }
 
 // MTLSConfig contains mTLS configuration
@@ -139,7 +140,7 @@ func New(config ServiceConfig, logger *otelzap.Logger) *Service {
 
 	// OAuth2 authenticator
 	if config.JWKS.URL != "" {
-		oauth2Auth, err := auth.NewOAuth2Authenticator(config.JWKS.URL, config.JWKS.Issuer, config.JWKS.Audience, config.JWKS.SigningAlgorithms, pm, logger, serviceName)
+		oauth2Auth, err := auth.NewOAuth2Authenticator(config.JWKS.URL, config.JWKS.Issuer, config.JWKS.Audience, config.JWKS.SigningAlgorithms, config.JWKS.AllowInsecure, pm, logger, serviceName)
 		if err != nil {
 			logger.Fatal("error initializing OAuth2 authenticator", zap.Error(err))
 		}


### PR DESCRIPTION
## Summary

JWKS responses define which keys can authenticate users. Fetching them over HTTP allows an on-path attacker to substitute keys.

This change requires HTTPS by default, adds an explicit `jwks.allow-insecure` option for development or trusted service meshes, and rejects HTTPS-to-HTTP redirects.

## Validation

- `make -C auth-callout test`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration to control whether HTTP JWKS endpoints are permitted, defaulting to disabled.
  * Added environment-variable support for enabling insecure JWKS access in local deployments.

* **Security**
  * JWKS retrieval now validates URLs, limits redirects, and prevents HTTPS-to-HTTP downgrades.
  * OAuth2 authentication rejects insecure JWKS URLs unless explicitly enabled.

* **Documentation**
  * Updated configuration examples to document the new JWKS security setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->