### PR TITLE
docs(event-bus): document MQTT QoS guidance

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -147,6 +147,21 @@ Supported QoS levels:
 - **QoS 1** — at least once (acknowledged delivery, backed by JetStream)
 - **QoS 2** — exactly once (backed by JetStream)
 
+DSX integration contracts use QoS 0 and eventual reconciliation. Messages must
+represent replaceable current state or repeatable intent. Higher QoS levels are
+available for MQTT client compatibility, not as a correctness mechanism. Refer
+to [Use QoS 0 and Reconcile](integrator-quickstart.md#use-qos-0-and-reconcile)
+
+NATS uses JetStream to persist incoming QoS 1 and QoS 2 messages and track
+subscriber acknowledgements. DSX Exchange defaults its internal MQTT streams
+and consumers to memory storage. This avoids disk I/O, but not the state,
+replication, and acknowledgement work. The
+[NATS MQTT implementation notes](https://github.com/nats-io/nats-server/blob/main/server/README-MQTT.md#2-use-of-jetstream)
+explain the underlying stream and consumer behavior.
+
+Retained messages are an optional startup optimization, not part of an
+integration's correctness or schema contract.
+
 ## Networking
 
 ### Exposed Ports

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,7 @@ The DSX Event Bus is a [NATS](https://nats.io/) messaging platform that provides
 The event bus supports the following capabilities:
 
 - **High availability.** 3-node cluster with topology-aware anti-affinity and automatic failover.
-- **Persistent messaging.** JetStream-backed QoS 0/1 and retained message support with in-memory replication.
+- **Persistent messaging.** JetStream-backed QoS 1/2 and retained message support with in-memory replication.
 - **Multi-cluster federation.** Leaf node connections between deployment layers with controlled topic filtering at each boundary.
 - **Declarative deployment.** Helm chart-based, ArgoCD-compatible, with no manual intervention required.
 
@@ -181,7 +181,9 @@ integration's correctness or schema contract.
 
 ## Persistence
 
-JetStream provides message persistence. MQTT QoS 1 messages and retained messages are stored in JetStream streams managed declaratively by the NACK controller.
+JetStream provides message persistence. MQTT QoS 1 and QoS 2 messages and
+retained messages are stored in JetStream streams managed declaratively by the
+NACK controller.
 
 - The built-in CPC account uses local JetStream for its own topic space and domain mapping to the CSC for cross-layer persistence; extra accounts keep their own account configuration on each cluster and are bridged by leaf nodes.
 - Stream configuration (storage type, replicas, max bytes) is set via `mqttStreams` Helm values

--- a/docs/bms-integration.md
+++ b/docs/bms-integration.md
@@ -44,13 +44,13 @@ MQTT is a lightweight publish/subscribe messaging protocol. There is no polling 
 
 Every point in the BMS specification has two distinct message types: a Value message and a Metadata message. This is one of the most important concepts to understand before you begin implementation.
 
-* **Value message:** Contains the live reading for a point. Published whenever the value changes, and republished every 100 seconds if it has not changed. The payload is always the same simple structure: a numeric value, a Unix timestamp in milliseconds, and a quality flag. Due to added system overhead, value messages should not be retained. QoS 0 should be used as the default unless critical, time-sensitive data points require a higher QoS.
+* **Value message:** Contains the live reading for a point. Published whenever the value changes, and republished every 100 seconds if it has not changed. The payload is always the same simple structure: a numeric value, a Unix timestamp in milliseconds, and a quality flag. Due to added system overhead, value messages should not be retained. Value messages must use QoS 0; periodic republication is the recovery mechanism when messages are lost.
 
 ```json
 { "value": 32.5, "timestamp": 1743620423000, "quality": 1 }
 ```
 
-* **Metadata message:** Describes what the point is — its engineering units, what object it belongs to, how it relates to other objects, and other context that makes the value interpretable. Published once at startup, then republished every 100 seconds. Metadata should be set as retained by the broker so new subscribers receive it immediately. Metadata is not expected to change very often unless there is a BMS design change.
+* **Metadata message:** Describes what the point is — its engineering units, what object it belongs to, how it relates to other objects, and other context that makes the value interpretable. Published once at startup, then republished every 100 seconds. Metadata messages must use QoS 0. They can be retained by the broker to reduce subscriber startup time. Consumers must not depend on retained delivery; periodic republication is the recovery mechanism. Metadata is not expected to change very often unless there is a BMS design change.
 
 <Note>
 Important: IT-side consumers MUST receive and process metadata before they can correctly interpret values. Metadata is what tells a Digital Twin that a value of 32.5 is a CDU secondary supply temperature in degrees Celsius, not a valve position in percent. Without metadata, the value is just a number.

--- a/docs/integrator-quickstart.md
+++ b/docs/integrator-quickstart.md
@@ -80,6 +80,33 @@ mqttx pub \
 For mTLS, configure the SDK's TLS options with the CA certificate, client
 certificate, and client key supplied by the operator.
 
+## Use QoS 0 and Reconcile
+
+DSX integration contracts use QoS 0. Model all operational data as replaceable
+current state or repeatable intent. QoS 1, QoS 2, and retained messages do not
+provide end-to-end reliability and must not be required for correctness.
+
+If a caller requires acknowledgement of one exact request, use a direct API
+instead of the event bus. Refer to [When not to use a Bus](stateless-async-bus.md#when-not-to-use-a-bus).
+
+Use the following eventual-consistency pattern:
+
+1. Publish complete current state, never deltas.
+1. Republish state periodically, as well as when it changes.
+1. Include a source timestamp so consumers can reject older observations. If the
+   source cannot guarantee timestamp ordering, define a source-scoped,
+   monotonically increasing revision.
+1. Make consumer updates idempotent, and expire state that is no longer refreshed.
+
+QoS 1 and QoS 2 remain available for compatibility with MQTT clients that
+require those protocol handshakes. They add NATS JetStream state and reduce
+throughput without removing the need for reconciliation.
+
+Retained messages can seed a new subscriber with a recent full snapshot and
+reduce startup latency. Treat this as an optional performance optimization:
+subscribers must still converge when no retained message is available. For
+implementation details, refer to [MQTT Support](architecture.md#mqtt-support).
+
 ## Choose an MQTT SDK
 
 Use the MQTT library that fits the application you are already building. These


### PR DESCRIPTION
## Summary

- Establish QoS 0 with eventual reconciliation as the DSX integration pattern.
- Document the NATS JetStream cost of QoS 1 and QoS 2.
- Clarify that retained messages are an optional startup optimization.
- Add concrete guidance for full snapshots, periodic republishing, ordering, and expiry.

## Validation

- `./tools/check-docs-mdx docs/architecture.md docs/integrator-quickstart.md`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified MQTT integration guidance, requiring QoS 0 with periodic reconciliation for replaceable state and repeatable intent.
  * Documented complete snapshots, ordering metadata, idempotent consumers, and stale-state expiration requirements.
  * Clarified that value and metadata messages use QoS 0; metadata retention is optional, with periodic republication supporting recovery.
  * Documented JetStream persistence and acknowledgements for QoS 1 and QoS 2, while internal streams and consumers default to in-memory storage.
  * Specified direct API use for exact-request acknowledgements instead of the event bus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->