### PR TITLE
ci(release): publish RC artifacts to components-dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,8 +257,8 @@ jobs:
           verify_dir="$(mktemp -d "$RUNNER_TEMP/dsx-rc-chart.XXXXXX")"
           trap 'rm -rf "$verify_dir"' EXIT
           for attempt in 1 2 3 4 5 6; do
-            helm repo update helm-repo-ngc
-            if helm pull "helm-repo-ngc/$CHART_NAME" \
+            if helm repo update helm-repo-ngc && \
+              helm pull "helm-repo-ngc/$CHART_NAME" \
               --version "$RELEASE_VERSION" \
               --destination "$verify_dir"; then
               break

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.release.outputs.tag }}
+          persist-credentials: false
 
       - name: Resolve immutable image metadata
         id: metadata
@@ -196,6 +197,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.release.outputs.tag }}
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-mise
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,25 @@ on:
   push:
     branches:
       - main
+      - "release/*"
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   release:
     name: Semantic Release
     runs-on: linux-amd64-cpu4
+    permissions:
+      contents: write
+    outputs:
+      publish-rc: ${{ steps.rc.outputs.should-publish }}
+      version: ${{ steps.rc.outputs.version }}
+      tag: ${{ steps.rc.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -27,7 +38,228 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/semantic-release@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
+
+      - name: Preview release candidate
+        id: preview
+        if: startsWith(github.ref, 'refs/heads/release/')
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/semantic-release@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          extra-plugins: conventional-changelog-conventionalcommits
+          semantic-version: 25.0.9
+          extra-plugins: conventional-changelog-conventionalcommits@9.3.1
+          dry-run: "true"
+
+      - name: Validate release branch target
+        if: startsWith(github.ref, 'refs/heads/release/') && steps.preview.outputs.new-release-published == 'true'
+        env:
+          PREVIEW_VERSION: ${{ steps.preview.outputs.new-release-version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          target_version="${GITHUB_REF_NAME#release/}"
+          if [[ ! "$target_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "Release branch must use release/X.Y.Z with canonical SemVer." >&2
+            exit 1
+          fi
+          if [[ "$PREVIEW_VERSION" != "$target_version"-rc.* ]]; then
+            echo "Branch $GITHUB_REF_NAME expects $target_version-rc.N, but semantic-release calculated $PREVIEW_VERSION." >&2
+            exit 1
+          fi
+
+      - name: Create semantic release
+        id: semantic
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/semantic-release@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          semantic-version: 25.0.9
+          extra-plugins: conventional-changelog-conventionalcommits@9.3.1
+
+      - name: Resolve RC artifact publishing
+        id: rc
+        if: startsWith(github.ref, 'refs/heads/release/')
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/resolve-release-candidate@d15d46d22d09f7111177a6f5e9f7ae9933e067b2
+        with:
+          new-release-published: ${{ steps.semantic.outputs.new-release-published }}
+          new-release-version: ${{ steps.semantic.outputs.new-release-version }}
+          new-release-git-tag: ${{ steps.semantic.outputs.new-release-git-tag }}
+
+  publish-rc-images:
+    name: Publish RC image (${{ matrix.name }})
+    needs: release
+    if: startsWith(github.ref, 'refs/heads/release/') && needs.release.outputs.publish-rc == 'true'
+    runs-on: linux-amd64-cpu4
+    environment: components-dev
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: auth-callout
+            context: auth-callout
+            dockerfile: auth-callout/build/package/Dockerfile
+          - name: dsx-agentgateway-bridge
+            context: dsx-agentgateway-bridge
+            dockerfile: dsx-agentgateway-bridge/Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+
+      - name: Resolve immutable image metadata
+        id: metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "created=$(git show -s --format=%cI HEAD)" >> "$GITHUB_OUTPUT"
+          echo "revision=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to NGC
+        uses: docker/login-action@v3
+        with:
+          registry: nvcr.io
+          username: $oauthtoken
+          password: ${{ secrets.NGC_DSX_COMPONENTS_PUSH_KEY }}
+
+      - name: Check for an existing immutable image
+        id: existing
+        env:
+          EXPECTED_REVISION: ${{ steps.metadata.outputs.revision }}
+          IMAGE_REF: nvcr.io/0837451325059433/components-dev/${{ matrix.name }}:${{ needs.release.outputs.version }}
+        shell: bash
+        run: |
+          set +e
+          scripts/verify-rc-image.sh "$IMAGE_REF" "$EXPECTED_REVISION"
+          status=$?
+          set -e
+          case "$status" in
+            0) echo "exists=true" >> "$GITHUB_OUTPUT" ;;
+            3) echo "exists=false" >> "$GITHUB_OUTPUT" ;;
+            *) exit "$status" ;;
+          esac
+
+      - name: Build and publish image
+        if: steps.existing.outputs.exists != 'true'
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/docker-build@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
+        with:
+          image: nvcr.io/0837451325059433/components-dev/${{ matrix.name }}
+          tags: ${{ needs.release.outputs.version }}
+          context: ${{ matrix.context }}
+          dockerfile: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: "true"
+          registry: nvcr.io
+          username: $oauthtoken
+          password: ${{ secrets.NGC_DSX_COMPONENTS_PUSH_KEY }}
+          cache-scope: rc-${{ matrix.name }}
+          labels: |
+            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
+            org.opencontainers.image.revision=${{ steps.metadata.outputs.revision }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ needs.release.outputs.version }}
+
+      - name: Verify published image
+        env:
+          EXPECTED_REVISION: ${{ steps.metadata.outputs.revision }}
+          IMAGE_REF: nvcr.io/0837451325059433/components-dev/${{ matrix.name }}:${{ needs.release.outputs.version }}
+        run: scripts/verify-rc-image.sh "$IMAGE_REF" "$EXPECTED_REVISION"
+
+  publish-rc-charts:
+    name: Publish RC chart (${{ matrix.name }})
+    needs: release
+    if: startsWith(github.ref, 'refs/heads/release/') && needs.release.outputs.publish-rc == 'true'
+    runs-on: linux-amd64-cpu4
+    environment: components-dev
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: auth-callout
+            chart_path: auth-callout/deploy
+            has_dependencies: false
+            align_local_auth_callout: false
+          - name: nats-event-bus
+            chart_path: deploy/nats-event-bus
+            has_dependencies: true
+            align_local_auth_callout: true
+          - name: dsx-agent-gateway
+            chart_path: deploy/dsx-agent-gateway
+            has_dependencies: true
+            align_local_auth_callout: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+
+      - uses: ./.github/actions/setup-mise
+        with:
+          cache-key: release-helm-yq
+          install-args: helm yq
+
+      - name: Stamp immutable chart metadata
+        env:
+          CHART_PATH: ${{ matrix.chart_path }}
+          SOURCE_REVISION: ${{ github.sha }}
+        run: |
+          yq -i \
+            '.annotations = (.annotations // {}) | .annotations."dsx.nvidia.com/source-revision" = strenv(SOURCE_REVISION)' \
+            "$CHART_PATH/Chart.yaml"
+
+      - name: Align local chart dependency versions
+        if: matrix.align_local_auth_callout
+        env:
+          RELEASE_VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          yq -i '(.version, .appVersion) = strenv(RELEASE_VERSION)' \
+            auth-callout/deploy/Chart.yaml
+          yq -i \
+            '(.dependencies[] | select(.name == "auth-callout").version) = strenv(RELEASE_VERSION)' \
+            deploy/nats-event-bus/Chart.yaml
+          yq -e \
+            '.dependencies[] | select(.name == "auth-callout" and .version == strenv(RELEASE_VERSION))' \
+            deploy/nats-event-bus/Chart.yaml >/dev/null
+
+      - name: Resolve chart dependencies
+        if: matrix.has_dependencies
+        env:
+          CHART_PATH: ${{ matrix.chart_path }}
+        run: helm dependency update "$CHART_PATH"
+
+      - name: Publish chart
+        id: publish
+        uses: dsx-ai-factory/dsx-github-actions/.github/actions/helm-package-push@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
+        with:
+          chart-path: ${{ matrix.chart_path }}
+          chart-version: ${{ needs.release.outputs.version }}
+          app-version: ${{ needs.release.outputs.version }}
+          lint: "true"
+          ngc-key: ${{ secrets.NGC_DSX_COMPONENTS_PUSH_KEY }}
+          ngc-path: 0837451325059433/components-dev
+          ngc-duplicate: skip
+
+      - name: Verify published chart
+        env:
+          CHART_NAME: ${{ matrix.name }}
+          EXPECTED_REVISION: ${{ github.sha }}
+          RELEASE_VERSION: ${{ needs.release.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          verify_dir="$(mktemp -d "$RUNNER_TEMP/dsx-rc-chart.XXXXXX")"
+          trap 'rm -rf "$verify_dir"' EXIT
+          helm pull "helm-repo-ngc/$CHART_NAME" \
+            --version "$RELEASE_VERSION" \
+            --destination "$verify_dir"
+          chart_archive="$verify_dir/$CHART_NAME-$RELEASE_VERSION.tgz"
+          chart_metadata="$verify_dir/Chart.yaml"
+          helm show chart "$chart_archive" > "$chart_metadata"
+          yq -e '
+            .version == strenv(RELEASE_VERSION) and
+            .appVersion == strenv(RELEASE_VERSION) and
+            .annotations."dsx.nvidia.com/source-revision" == strenv(EXPECTED_REVISION)
+          ' "$chart_metadata" >/dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,9 @@ jobs:
             echo "Release branch must use release/X.Y.Z with canonical SemVer." >&2
             exit 1
           fi
-          if [[ "$PREVIEW_VERSION" != "$target_version"-rc.* ]]; then
+          rc_prefix="${target_version}-rc."
+          rc_number="${PREVIEW_VERSION#"$rc_prefix"}"
+          if [[ "$PREVIEW_VERSION" != "$rc_prefix"* || ! "$rc_number" =~ ^[1-9][0-9]*$ ]]; then
             echo "Branch $GITHUB_REF_NAME expects $target_version-rc.N, but semantic-release calculated $PREVIEW_VERSION." >&2
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,9 +256,19 @@ jobs:
           set -euo pipefail
           verify_dir="$(mktemp -d "$RUNNER_TEMP/dsx-rc-chart.XXXXXX")"
           trap 'rm -rf "$verify_dir"' EXIT
-          helm pull "helm-repo-ngc/$CHART_NAME" \
-            --version "$RELEASE_VERSION" \
-            --destination "$verify_dir"
+          for attempt in 1 2 3 4 5 6; do
+            helm repo update helm-repo-ngc
+            if helm pull "helm-repo-ngc/$CHART_NAME" \
+              --version "$RELEASE_VERSION" \
+              --destination "$verify_dir"; then
+              break
+            fi
+            if [[ "$attempt" == 6 ]]; then
+              echo "NGC did not expose $CHART_NAME $RELEASE_VERSION after 6 attempts." >&2
+              exit 1
+            fi
+            sleep 10
+          done
           chart_archive="$verify_dir/$CHART_NAME-$RELEASE_VERSION.tgz"
           chart_metadata="$verify_dir/Chart.yaml"
           helm show chart "$chart_archive" > "$chart_metadata"

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,12 @@
 {
-  "branches": ["main"],
+  "branches": [
+    "main",
+    {
+      "name": "release/2.9.3",
+      "channel": "rc",
+      "prerelease": "rc"
+    }
+  ],
   "tagFormat": "v${version}",
   "plugins": [
     ["@semantic-release/commit-analyzer", {

--- a/README.md
+++ b/README.md
@@ -89,6 +89,32 @@ See [local/mqttbs/README.md](local/mqttbs/README.md) for smoke-sized options.
 
 DSX Exchange follows [Semantic Versioning](https://semver.org/) (`vX.Y.Z`), automated via semantic-release. A new version is published automatically when a semantic-release compliant commit is merged to `main`.
 
+Release candidates use a protected `release/<target-version>` branch that is
+listed explicitly in `.releaserc.json`. The first semantic-release compliant
+commit merged to that branch creates `vX.Y.Z-rc.1`; later qualifying merges
+increment the RC number. The workflow checks that the calculated version
+matches the target version in the branch name before creating the tag. Each RC
+uses one version for all artifacts published to the DSX `components-dev` NGC
+team. Replace the configured release branch for each release cycle rather than
+using a glob with the shared `rc` prerelease identifier.
+
+Published artifacts:
+
+- Container images: `auth-callout`, `dsx-agentgateway-bridge`
+- Helm charts: `auth-callout`, `nats-event-bus`, `dsx-agent-gateway`
+
+The `components-dev` GitHub environment must provide the
+`NGC_DSX_COMPONENTS_PUSH_KEY` secret and allow deployments only from
+`release/*`. A repository ruleset keeps those branches PR-only and requires a
+Code Owner approval. A failed artifact job can be rerun: the workflow reuses
+the single RC tag on the same commit, verifies existing artifacts against that
+commit, and publishes only missing artifacts. Final tags from `main` continue
+through the existing GitLab mirror publishing path.
+
+See the
+[shared RC publishing contract](https://github.com/dsx-ai-factory/dsx-github-actions/blob/main/docs/release-candidate-publishing.md)
+when onboarding another GitHub-hosted DSX component.
+
 | Commit prefix | Version bump | When to use |
 |---------------|-------------|-------------|
 | `fix:` | Patch (Z) | Bug fixes, CVE remediation |

--- a/scripts/verify-rc-image.sh
+++ b/scripts/verify-rc-image.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 IMAGE_REF EXPECTED_REVISION" >&2
+  exit 64
+fi
+
+image_ref="$1"
+expected_revision="$2"
+temp_root="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+manifest_file="$(mktemp "$temp_root/dsx-rc-manifest.XXXXXX")"
+image_file="$(mktemp "$temp_root/dsx-rc-image.XXXXXX")"
+error_file="$(mktemp "$temp_root/dsx-rc-error.XXXXXX")"
+trap 'rm -f "$manifest_file" "$image_file" "$error_file"' EXIT
+
+if docker buildx imagetools inspect --format '{{json .Manifest}}' \
+  "$image_ref" >"$manifest_file" 2>"$error_file"; then
+  :
+else
+  status=$?
+  if grep -Eqi 'manifest unknown|not found|404' "$error_file"; then
+    exit 3
+  fi
+  cat "$error_file" >&2
+  exit "$status"
+fi
+
+if ! jq -e '
+  [.manifests[]?
+    | select(.platform.os == "linux")
+    | .platform.architecture]
+  | unique
+  | . as $platforms
+  | ($platforms | index("amd64") != null)
+    and ($platforms | index("arm64") != null)
+' "$manifest_file" >/dev/null; then
+  echo "$image_ref does not contain both linux/amd64 and linux/arm64." >&2
+  exit 1
+fi
+
+docker buildx imagetools inspect --format '{{json .Image}}' \
+  "$image_ref" >"$image_file"
+
+if ! jq -e --arg expected "$expected_revision" '
+  [..
+    | objects
+    | select(has("config"))
+    | .config
+    | select(type == "object")
+    | (.Labels // {})["org.opencontainers.image.revision"]
+    | select(type == "string")] as $revisions
+  | ($revisions | length) >= 2
+    and ($revisions | all(. == $expected))
+' "$image_file" >/dev/null; then
+  echo "$image_ref does not match source revision $expected_revision on every platform." >&2
+  exit 1
+fi
+
+echo "Verified $image_ref at source revision $expected_revision."


### PR DESCRIPTION
## Description

Implements the DSX Exchange release-candidate path for
[DSXOSBRNG-1576](https://jirasw.nvidia.com/browse/DSXOSBRNG-1576) and
[DSXOSBRNG-1577](https://jirasw.nvidia.com/browse/DSXOSBRNG-1577).

- Configures the explicit `release/2.9.3` semantic-release branch with the
  `rc` prerelease identifier.
- Runs a pinned semantic-release dry run first and fails before tag creation if
  the calculated version does not match the branch target.
- Publishes `auth-callout` and `dsx-agentgateway-bridge` multi-architecture
  images to NGC `components-dev`.
- Publishes the `auth-callout`, `nats-event-bus`, and `dsx-agent-gateway` Helm
  charts at the same RC version.
- Makes reruns fail closed: existing artifacts are reused only when their
  source revision matches the RC commit, and image tags are never overwritten.
- Adds per-branch concurrency and documents the release and rerun workflow.

The shared RC resolver is pinned to the merged `dsx-github-actions` commit
`d15d46d22d09f7111177a6f5e9f7ae9933e067b2`. The repository's
`components-dev` environment, scoped NGC secret, deployment branch policy, and
release-branch ruleset were configured separately. No credential is stored in
the repository.

This PR intentionally targets `release/2.9.3`. Merging it creates and validates
`v2.9.3-rc.1` without changing the current stable-release behavior on `main`.

## Validation

- `actionlint` on `.github/workflows/release.yml`
- `bash -n scripts/verify-rc-image.sh`
- `jq empty .releaserc.json`
- `git diff --check HEAD^ HEAD`
- Packaged all three charts locally as `2.9.3-rc.1`; confirmed chart version,
  app version, source revision annotation, and the embedded `auth-callout`
  dependency version.

`make check` could not run on this macOS host because the repository's `mise`
tool is unavailable. The PR checks remain the source-of-truth full validation.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/dsx-ai-factory/dsx-exchange/blob/main/CONTRIBUTING.md).
- [x] Documentation updated, if needed.
- [x] Tests or validation added/updated, if needed.
- [x] License headers are present on applicable source files.
- [x] Third-party license inventory updated, if dependencies changed.
- [ ] Security-sensitive changes were reviewed privately before public disclosure.
- [x] My commits are signed off (`git commit -s`) per the DCO.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added release-candidate publishing for protected `release/<target-version>` branches.
  - RC container images and Helm charts are published with version and source metadata validation.
  - Multi-architecture images support Linux `amd64` and `arm64` platforms.
  - Matching existing artifacts can be detected to avoid unnecessary rebuilds.
  - Added validation for RC version numbering and immutable published artifacts.
  - Added verification for published image platforms and source revisions.

- **Documentation**
  - Added guidance for RC validation, publishing requirements, branch rules, reruns, and available images and charts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->