### PR TITLE
fix(ci): pin conventional changelog preset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,4 @@ jobs:
       - uses: dsx-ai-factory/dsx-github-actions/.github/actions/semantic-release@0969f64c3efa9e757135cbf457ea13cde4c3fa38 # v1.17.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          extra-plugins: conventional-changelog-conventionalcommits
+          extra-plugins: conventional-changelog-conventionalcommits@9.3.1


### PR DESCRIPTION
## Description

Pin `conventional-changelog-conventionalcommits` to version 9.3.1.

The unversioned plugin now resolves to version 10. That version requires
`conventional-changelog-writer` version 9 or later. The shared semantic-release
action currently loads an older writer, so release-note generation fails before
semantic-release publishes the release.

Version 9.3.1 is compatible with the current semantic-release plugin stack.

This is a known issue: https://github.com/semantic-release/release-notes-generator/issues/992

## Validation

- `git diff --check`
- Parsed `.github/workflows/release.yml` with Ruby YAML support.
- `make check` could not start because `mise` is not installed on this host.
- `bash scripts/license.sh check` could not start because `addlicense` is not installed on this host.

## Checklist

- [x] Documentation is not required because this change does not alter product behavior.
- [x] Workflow syntax validation covers the changed configuration.
- [x] The existing license header is present.
- [x] The third-party Go license inventory is not affected.
- [x] This change does not disclose a security issue.
- [x] The commit includes a DCO sign-off.
